### PR TITLE
Added extract_metadata.py script for DICOM metadata extraction

### DIFF
--- a/Scripts/extract_metadata.py
+++ b/Scripts/extract_metadata.py
@@ -11,6 +11,7 @@ def extract_metadata(dicom_dir):
     for root, _, files in os.walk(dicom_dir):
         for file in files:
             if file.endswith(".dcm"):
+                print(f"Found DICOM file: {file}")  # Debug line
                 try:
                     dcm = pydicom.dcmread(os.path.join(root, file))
                     metadata = {

--- a/Scripts/extract_metadata.py
+++ b/Scripts/extract_metadata.py
@@ -1,0 +1,36 @@
+import os
+import pydicom
+import pandas as pd
+
+def extract_metadata(dicom_dir):
+    """
+    Extract metadata from all DICOM files in the given directory.
+    """
+    metadata_list = []
+
+    for root, _, files in os.walk(dicom_dir):
+        for file in files:
+            if file.endswith(".dcm"):
+                try:
+                    dcm = pydicom.dcmread(os.path.join(root, file))
+                    metadata = {
+                        "PatientID": getattr(dcm, "PatientID", None),
+                        "StudyDate": getattr(dcm, "StudyDate", None),
+                        "Modality": getattr(dcm, "Modality", None),
+                        "StudyDescription": getattr(dcm, "StudyDescription", None),
+                        "SeriesDescription": getattr(dcm, "SeriesDescription", None),
+                        "BodyPartExamined": getattr(dcm, "BodyPartExamined", None),
+                        "Manufacturer": getattr(dcm, "Manufacturer", None),
+                        "FilePath": os.path.join(root, file)
+                    }
+                    metadata_list.append(metadata)
+                except Exception as e:
+                    print(f"Error reading {file}: {e}")
+
+    return pd.DataFrame(metadata_list)
+
+
+if __name__ == "__main__":
+    path = "path/to/dicom/files"  # Replace this with the actual folder path
+    df = extract_metadata(path)
+    print(df.head())

--- a/Scripts/extract_metadata.py
+++ b/Scripts/extract_metadata.py
@@ -1,6 +1,7 @@
 import os
 import pydicom
 import pandas as pd
+import argparse
 import logging
 logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
 
@@ -37,6 +38,17 @@ def extract_metadata(dicom_dir):
 
 
 if __name__ == "__main__":
-    path = "path/to/dicom/files"  # Replace this with the actual folder path
-    df = extract_metadata(path)
-    print(df.head())
+    path = "C:\Users\asus\Diomede"  # Replace this with the actual folder path
+    # Parse command-line arguments
+parser = argparse.ArgumentParser(description="Extract metadata from DICOM files and save to CSV.")
+parser.add_argument("input_folder", help="Path to the folder containing DICOM files")
+parser.add_argument("output_file", nargs="?", default="dicom_metadata.csv", help="Output CSV file name (default: dicom_metadata.csv)")
+args = parser.parse_args()
+
+# Run metadata extraction
+df = extract_metadata(args.input_folder)
+
+# Save to CSV
+df.to_csv(args.output_file, index=False)
+print(f"Metadata saved to {args.output_file}")
+

--- a/Scripts/extract_metadata.py
+++ b/Scripts/extract_metadata.py
@@ -1,6 +1,9 @@
 import os
 import pydicom
 import pandas as pd
+import logging
+logging.basicConfig(level=logging.INFO, format='%(levelname)s:%(message)s')
+
 
 def extract_metadata(dicom_dir):
     """
@@ -26,7 +29,9 @@ def extract_metadata(dicom_dir):
                     }
                     metadata_list.append(metadata)
                 except Exception as e:
-                    print(f"Error reading {file}: {e}")
+                    logging.error(f"Error reading {file}: {e}")
+                    continue  # this makes the script skip the file and continue
+
 
     return pd.DataFrame(metadata_list)
 


### PR DESCRIPTION
## Summary
- Implemented a script (`extract_metadata.py`) to extract metadata from DICOM files.
- Extracts fields: `PatientID`, `StudyDate`, `Modality`, and saves to a CSV file.
- Uses `pydicom` and `pandas` for processing.

## How to Test
- Run `python Scripts/extract_metadata.py` with a folder containing `.dcm` files.
- Metadata will be saved in `dicom_metadata.csv`.

## Improvements
- Additional metadata fields can be extracted in future updates.
