### PR TITLE
Add missing pandas dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv>=0.19.0
 requests>=2.26.0
 pytest>=6.2.0
 flask-cors>=3.0.10
+pandas>=1.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
         'pydicom>=2.3.0',
         'flask-sqlalchemy>=2.5.0',
         'python-dotenv>=0.19.0',
-        'requests>=2.26.0'
+        'requests>=2.26.0',
+        'pandas>=1.3.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Some scripts in the repository use the `pandas` library, including:
- dicom-album-env/Scripts/extract_metadata.py  
- dicom-album-env/Scripts/query_metadata.py  
- dicom-album-env/app.py  

However, `pandas` was not listed as a dependency in `requirements.txt` or `setup.py`. This could lead to a `ModuleNotFoundError` when running these scripts on a fresh installation.
This PR adds `pandas` to the dependency list so the project can be installed and used without missing dependency issues.