### PR TITLE
Add album-workflow metadata validation helper with tests

### DIFF
--- a/Diomedex/utils/dicom_helpers.py
+++ b/Diomedex/utils/dicom_helpers.py
@@ -6,12 +6,19 @@ import pydicom
 
 LOG = logging.getLogger(__name__)
 
+# Tags required for album creation workflow
+# SeriesInstanceUID and StudyInstanceUID are critical — without them
+# a file cannot be grouped into any album
+_CRITICAL_TAGS = ("SeriesInstanceUID", "StudyInstanceUID")
+
+# Important but not blocking — albums can be created without these,
+# but queries and filtering will be degraded
+_IMPORTANT_TAGS = ("PatientID", "Modality", "StudyDate")
+
 
 def safe_load_dicom_file(file_path: Union[str, PathLike]):
     """Safely load a DICOM file from disk.
-
     Returns the pydicom Dataset for valid files or None when invalid/malformed.
-
     Reasoning:
       - Centralizes DICOM error handling once (single source of truth).
       - Avoids duplication in multiple modules.
@@ -20,11 +27,68 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
     try:
         dataset = pydicom.dcmread(file_path)
     except (pydicom.errors.InvalidDicomError,
-            pydicom.errors.PydicomError,
             EOFError,
             ValueError,
             OSError) as ex:
         LOG.warning("Skipping invalid or corrupted DICOM file: %s (%s)", file_path, ex)
         return None
-
     return dataset
+
+
+def extract_basic_metadata(file_path: Union[str, PathLike]):
+    """Extract key DICOM fields needed for album creation.
+    Returns a dict with None defaults for any missing field.
+    """
+    keys = ("PatientID", "StudyDate", "Modality",
+            "SeriesInstanceUID", "StudyInstanceUID")
+    dataset = safe_load_dicom_file(file_path)
+    if dataset is None:
+        return dict.fromkeys(keys)
+    return {key: dataset.get(key) for key in keys}
+
+
+def validate_dicom_for_album(metadata: dict) -> dict:
+    """Validate extracted DICOM metadata for album-workflow completeness.
+
+    Albums are organised at the SeriesInstanceUID level — series are the
+    atomic unit of a DICOM album.  A file that is missing a critical tag
+    cannot be placed into any album and must be rejected early, before it
+    silently corrupts query results or produces orphaned album entries.
+
+    Args:
+        metadata: dict returned by extract_basic_metadata (or any dict
+                  containing DICOM tag name → value pairs).
+
+    Returns:
+        A structured result dict with three keys:
+          status           - "valid" | "invalid" | "warning"
+          missing_critical - list of critical tag names that are absent/None
+          missing_optional - list of important tag names that are absent/None
+
+    Usage:
+        metadata = extract_basic_metadata(file_path)
+        result = validate_dicom_for_album(metadata)
+        if result["status"] == "invalid":
+            # skip this file — cannot be grouped into an album
+    """
+    missing_critical = [
+        tag for tag in _CRITICAL_TAGS
+        if not metadata.get(tag)
+    ]
+    missing_optional = [
+        tag for tag in _IMPORTANT_TAGS
+        if not metadata.get(tag)
+    ]
+
+    if missing_critical:
+        status = "invalid"
+    elif missing_optional:
+        status = "warning"
+    else:
+        status = "valid"
+
+    return {
+        "status": status,
+        "missing_critical": missing_critical,
+        "missing_optional": missing_optional,
+    }

--- a/tests/test_dicom_helpers.py
+++ b/tests/test_dicom_helpers.py
@@ -1,0 +1,77 @@
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'Diomedex', 'utils'))
+from dicom_helpers import validate_dicom_for_album, extract_basic_metadata
+
+import pytest
+
+class TestValidateDicomForAlbum:
+    """Tests for album-workflow metadata validation.
+
+    Albums are organised at SeriesInstanceUID level — these tests confirm
+    that files missing critical grouping tags are rejected before they can
+    silently corrupt album contents or query results.
+    """
+
+    def test_all_fields_present_returns_valid(self):
+        metadata = {
+            "SeriesInstanceUID": "1.2.3.4.5",
+            "StudyInstanceUID": "1.2.3.4.6",
+            "PatientID": "P001",
+            "Modality": "CT",
+            "StudyDate": "20200101",
+        }
+        result = validate_dicom_for_album(metadata)
+        assert result["status"] == "valid"
+        assert result["missing_critical"] == []
+        assert result["missing_optional"] == []
+
+    def test_missing_series_uid_returns_invalid(self):
+        # SeriesInstanceUID is the atomic unit of album grouping —
+        # a file without it cannot be placed into any album
+        metadata = {
+            "SeriesInstanceUID": None,
+            "StudyInstanceUID": "1.2.3.4.6",
+            "PatientID": "P001",
+            "Modality": "CT",
+            "StudyDate": "20200101",
+        }
+        result = validate_dicom_for_album(metadata)
+        assert result["status"] == "invalid"
+        assert "SeriesInstanceUID" in result["missing_critical"]
+
+    def test_missing_study_uid_returns_invalid(self):
+        metadata = {
+            "SeriesInstanceUID": "1.2.3.4.5",
+            "StudyInstanceUID": None,
+            "PatientID": "P001",
+            "Modality": "CT",
+            "StudyDate": "20200101",
+        }
+        result = validate_dicom_for_album(metadata)
+        assert result["status"] == "invalid"
+        assert "StudyInstanceUID" in result["missing_critical"]
+
+    def test_missing_optional_field_returns_warning(self):
+        # Missing Modality degrades filtering but album can still be created
+        metadata = {
+            "SeriesInstanceUID": "1.2.3.4.5",
+            "StudyInstanceUID": "1.2.3.4.6",
+            "PatientID": "P001",
+            "Modality": None,
+            "StudyDate": "20200101",
+        }
+        result = validate_dicom_for_album(metadata)
+        assert result["status"] == "warning"
+        assert "Modality" in result["missing_optional"]
+
+    def test_corrupted_file_extract_returns_all_none(self, tmp_path):
+        # A corrupted file should produce all-None metadata —
+        # validate_dicom_for_album must reject it cleanly
+        fake_file = tmp_path / "corrupt.dcm"
+        fake_file.write_bytes(b"this is not a dicom file")
+        metadata = extract_basic_metadata(str(fake_file))
+        result = validate_dicom_for_album(metadata)
+        assert result["status"] == "invalid"
+        assert "SeriesInstanceUID" in result["missing_critical"]
+        assert "StudyInstanceUID" in result["missing_critical"]


### PR DESCRIPTION
## What this PR does
Adds `validate_dicom_for_album()` to `Diomedex/utils/dicom_helpers.py`.

The function validates extracted DICOM metadata for album-workflow
completeness before files enter the album creation pipeline.

Albums are organised at SeriesInstanceUID level, a file missing this
tag cannot be grouped into any album and must be rejected early, before
it silently corrupts query results or produces orphaned album entries.

**Critical tags** (SeriesInstanceUID, StudyInstanceUID): file is marked
`invalid` if either is missing, these are the grouping keys for album
organisation.

**Important tags** (PatientID, Modality, StudyDate): file is marked
`warning` if missing, album can still be created but queries are
degraded.

Returns structured result: `{status, missing_critical, missing_optional}`

## Why it's needed
Currently `extract_basic_metadata()` returns `None` silently for missing
fields. Files with missing SeriesInstanceUID would enter the album
pipeline and produce ungroupable entries. This validation layer catches
those cases before they reach album creation.

## Files changed
- `Diomedex/utils/dicom_helpers.py` - added `validate_dicom_for_album()`
- `tests/test_dicom_helpers.py`- 5 focused test cases

## How to test
```bash
pytest tests/test_dicom_helpers.py -v
```

## Related
Project #13 — Creating shareable albums from locally stored DICOM images