### PR TITLE
Fix Broken Import in test_albums.py

### DIFF
--- a/Diomedex/__init__.py
+++ b/Diomedex/__init__.py
@@ -5,13 +5,14 @@ from dotenv import load_dotenv
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from dotenv import load_dotenv
-from .albums.routes import albums_bp
-from .routing.routes import routing_bp
-from .routing import DICOMRouter
 
 load_dotenv()
 
 db = SQLAlchemy()
+
+from .albums.routes import albums_bp
+from .routing.routes import routing_bp
+from .routing import DICOMRouter
 
 def create_app(enable_routing=False):
     app = Flask(__name__)
@@ -24,6 +25,7 @@ def create_app(enable_routing=False):
         secret_key = secrets.token_hex(32)
     app.config['SECRET_KEY'] = secret_key
 
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///diomede.db')
     # Initialize db with app
     db.init_app(app)
     

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 from typing import List, Dict
 
-from ..models import db, DICOMFile
+from .models import db, DICOMFile
 from ..utils.dicom_helpers import safe_load_dicom_file
 
 LOG = logging.getLogger(__name__)

--- a/Diomedex/utils/dicom_helpers.py
+++ b/Diomedex/utils/dicom_helpers.py
@@ -20,7 +20,6 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
     try:
         dataset = pydicom.dcmread(file_path)
     except (pydicom.errors.InvalidDicomError,
-            pydicom.errors.PydicomError,
             EOFError,
             ValueError,
             OSError) as ex:

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -1,7 +1,7 @@
 import pytest
-from diomede.albums.core import DICOMAlbumCreator
-from diomede.albums.models import DICOMFile, Album, db
-from diomede import create_app
+from Diomedex.albums.core import DICOMAlbumCreator
+from Diomedex.albums.models import DICOMFile, Album, db
+from Diomedex import create_app
 
 @pytest.fixture
 def app():
@@ -15,10 +15,24 @@ def app():
         db.drop_all()
 
 def test_scan_directory(tmp_path, app):
-    # Create test DICOM file (simplified)
+    import pydicom
+    from pydicom.dataset import FileDataset, FileMetaDataset
+    from pydicom.uid import UID
+
     dcm_file = tmp_path / "test.dcm"
-    dcm_file.write_bytes(b'DICM_TEST_DATA')
     
+    file_meta = FileMetaDataset()
+    file_meta.MediaStorageSOPClassUID = UID('1.2.840.10008.5.1.4.1.1.2')
+    file_meta.MediaStorageSOPInstanceUID = UID('1.2.3')
+    file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
+    
+    ds = FileDataset(str(dcm_file), {}, file_meta=file_meta, preamble=b"\0" * 128)
+    ds.PatientID = "12345"
+    ds.StudyInstanceUID = "1.2.3.4"
+    ds.Modality = "CT"
+    ds.is_little_endian = True
+    ds.is_implicit_VR = False
+    ds.save_as(str(dcm_file))
     with app.app_context():
         creator = DICOMAlbumCreator(str(tmp_path))
         files = creator.scan_directory(str(tmp_path))


### PR DESCRIPTION
When I fixed the import name to get the tests running, I found few other hidden bugs that were preventing the app from starting up properly. I have fixed those as well so the test suite can actually run and pass.

Change I have made:

- Fixed the test imports: updated test_albums.py to import from Diomedex.
- In Diomedex/init.py, the blueprints were being imported before db was initialized, which caused a circular dependency loop. I  just moved db = SQLAlchemy() above the blueprint imports.
-  Added a fallback SQLALCHEMY_DATABASE_URI so flask-sqlalchemy doesn't throw a runtime error on startup if the environment variable isn't set.
- core.py was trying to import .. models but models is in the same directory so changed it to . models
- pydicom.errors.PydicomError exception class doesn't actually exist in the current pydicom package (outdated), This was causing crashes when scanning invalid files. I just removed it from the catch block.
- updated sample DICOM generation:
- The test was generating raw text bytes (b'DICM_TEST_DATA'), which pydicom was correctly rejecting as invalid. I updated the test to generate a structurally valid (but minimal) DICOM file so the scanner actually processes 