### PR TITLE
feat: Scans DICOM files, extracts metadata, avoids duplicates, stores…

### DIFF
--- a/dicom-album-env/Scripts/dicom_indexer.py
+++ b/dicom-album-env/Scripts/dicom_indexer.py
@@ -21,15 +21,15 @@ Base = declarative_base()
 class DICOMIndex(Base):
     __tablename__ = "DICOMIndex"
 
-    id= Column(Integer, primary_key=True)
-    file_path= Column(String(500), unique=True, nullable=False)
-    patient_id= Column(String(100), index=True)
-    series_description= Column(String(300))
-    study_uid= Column(String(200), index=True)
-    study_date= Column(DateTime)
-    series_uid= Column(String(200))
-    indexed_at= Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
-    modality= Column(String(50))
+    id = Column(Integer, primary_key=True)
+    file_path = Column(String(500), unique=True, nullable=False)
+    patient_id = Column(String(100), index=True)
+    series_description = Column(String(300))
+    study_uid = Column(String(200), index=True)
+    study_date = Column(DateTime)
+    series_uid = Column(String(200))
+    indexed_at = Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+    modality = Column(String(50))
 
     def __repr__(self):
         return f"<DICOMIndex {self.file_path}>"

--- a/dicom-album-env/Scripts/dicom_indexer.py
+++ b/dicom-album-env/Scripts/dicom_indexer.py
@@ -1,0 +1,125 @@
+import os
+import argparse
+import logging
+from datetime import datetime, timezone
+
+import pydicom
+from pydicom.errors import InvalidDicomError
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+Base = declarative_base()
+
+
+class DICOMIndex(Base):
+    __tablename__ = "DICOMIndex"
+
+    id= Column(Integer, primary_key=True)
+    file_path= Column(String(500), unique=True, nullable=False)
+    patient_id= Column(String(100), index=True)
+    series_description= Column(String(300))
+    study_uid= Column(String(200), index=True)
+    study_date= Column(DateTime)
+    series_uid= Column(String(200))
+    indexed_at= Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+    modality= Column(String(50))
+
+    def __repr__(self):
+        return f"<DICOMIndex {self.file_path}>"
+
+def parse_study_date(raw):
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(str(raw).strip(), "%Y%m%d")
+    except ValueError:
+        return None
+
+def extract_metadata(filepath):
+    try:
+        ds = pydicom.dcmread(filepath, stop_before_pixels=True)
+    except InvalidDicomError:
+        logger.warning("Skipping non-DICOM file: %s", filepath)
+        return None
+    except Exception as exc:
+        logger.warning("Could not read %s — %s", filepath, exc)
+        return None
+
+    return {
+        "file_path": os.path.abspath(filepath),
+        "patient_id": getattr(ds, "PatientID", None),
+        "study_uid": getattr(ds, "StudyInstanceUID", None),
+        "series_uid": getattr(ds, "SeriesInstanceUID", None),
+        "modality": getattr(ds, "Modality", None),
+        "study_date": parse_study_date(getattr(ds, "StudyDate", None)),
+        "series_description": getattr(ds, "SeriesDescription", None),}
+
+def iter_dicom_files(folder):
+    for root, _, files in os.walk(folder):
+        for fname in files:
+            if fname.lower().endswith((".dcm", ".dicom")) or "." not in fname:
+                yield os.path.join(root, fname)
+
+def index_folder(folder, db_path):
+    engine= create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    Session= sessionmaker(bind=engine)
+    session= Session()
+    existing= {row[0] for row in session.query(DICOMIndex.file_path).all()}
+    added= 0
+    skipped= 0
+    failed= 0
+
+    for filepath in iter_dicom_files(folder):
+        abs_path= os.path.abspath(filepath)
+        if abs_path in existing:
+            skipped += 1
+            continue
+        meta= extract_metadata(filepath)
+        if meta is None:
+            failed += 1
+            continue
+        session.add(DICOMIndex(**meta))
+        existing.add(abs_path)
+        added += 1
+        if added % 100 == 0:
+            session.commit()
+            logger.info("Indexed %d files so far ...", added)
+
+    session.commit()
+    session.close()
+    logger.info("Done — added: %d  skipped: %d  failed: %d", added, skipped, failed)
+    logger.info("Database written to: %s", os.path.abspath(db_path))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan a folder of DICOM files and index their metadata into SQLite."
+    )
+    parser.add_argument(
+        "folder",
+        help="Path to the folder containing DICOM files (scanned recursively).",
+    )
+    parser.add_argument(
+        "--db",
+        default="dicom_index.db",
+        help="Output SQLite database file (default: dicom_index.db).",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.folder):
+        logger.error("'%s' is not a valid directory.", args.folder)
+        return
+
+    logger.info("Scanning folder: %s", os.path.abspath(args.folder))
+    index_folder(args.folder, args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dicomIndexer.py
+++ b/tests/test_dicomIndexer.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dicom-album-env", "Scripts"))
+
+from dicom_indexer import extract_metadata, parse_study_date, index_folder, DICOMIndex
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydicom.data import get_testdata_file
+
+@pytest.fixture
+def sample_dcm():
+    return get_testdata_file("CT_small.dcm")
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_index.db")
+
+@pytest.fixture
+def tmp_dicom_dir(tmp_path, sample_dcm):
+    import shutil
+    shutil.copy(sample_dcm, tmp_path / "CT_small.dcm")
+    (tmp_path / "not_dicom.txt").write_text("this is not a dicom file")
+    return str(tmp_path)
+
+class TestParseStudyDate:
+    def test_valid_date_string(self):
+        result = parse_study_date("20200115")
+        assert result is not None
+        assert result.year == 2020
+    def test_none_input(self):
+        assert parse_study_date(None) is None
+    def test_empty_string(self):
+        assert parse_study_date("") is None
+    def test_invalid_format(self):
+        assert parse_study_date("not-a-date") is None
+
+class TestExtractMetadata:
+    def test_returns_dict_for_valid_dicom(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta is not None
+        assert isinstance(meta, dict)
+    def test_returns_none_for_non_dicom(self, tmp_path):
+        fake = tmp_path / "fake.dcm"
+        fake.write_text("this is not dicom content")
+        assert extract_metadata(str(fake)) is None
+    def test_contains_required_keys(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        for key in ["file_path", "patient_id", "study_uid", "modality", "study_date"]:
+            assert key in meta
+    def test_file_path_is_absolute(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert os.path.isabs(meta["file_path"])
+    def test_modality_is_ct(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta["modality"] == "CT"
+
+class TestIndexFolder:
+    def test_indexes_dicom_file(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count >= 1
+    def test_skips_non_dicom_files(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_no_duplicates_on_reindex(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_modality_stored_correctly(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        record = session.query(DICOMIndex).first()
+        session.close()
+        assert record.modality == "CT"

--- a/tests/test_dicomIndexer.py
+++ b/tests/test_dicomIndexer.py
@@ -63,7 +63,7 @@ class TestIndexFolder:
         session = sessionmaker(bind=engine)()
         count = session.query(DICOMIndex).count()
         session.close()
-        assert count >= 1
+        assert count == 1
     def test_skips_non_dicom_files(self, tmp_dicom_dir, tmp_db):
         index_folder(tmp_dicom_dir, tmp_db)
         engine = create_engine(f"sqlite:///{tmp_db}")


### PR DESCRIPTION
### **SUMMARY**
_______________________________________________________
Adds a new DICOM indexing module that scans for DICOM files, avoids unnecessary image data(like pixeldata etc), avoids duplicates, extracts metadata, stores them in SQLite database and Logs everything. 

### **Features Implemented**

- Recursively scans folders for DICOM files
- Extracts metadata:
  - PatientID
  - StudyInstanceUID
  - SeriesInstanceUID
  - Modality
  - StudyDate
  - SeriesDescription
- Converts study date into proper datetime format
- Skips non-DICOM files safely
- Avoids duplicate indexing using file paths
- Stores all metadata in SQLite database using SQLAlchemy

### **Database fields stored**

- file_path
- patient_id
- study_uid
- series_uid
- modality
- study_date
- series_description
- indexed_at

## **Test Plan**
### Unit tests include:
- Date parsing:
  - valid format
  - invalid format
  - empty input
- Metadata extraction:
  - valid DICOM
  - non-DICOM handling
  - required keys validation
- Indexing:
  - indexing DICOM files
  - skipping non-DICOM files
  - avoiding duplicates on re-index
  - verifying stored modality

## Notes
- Used `pydicom` for reading DICOM files
- Used `SQLAlchemy` for database operations
- Optimized reading using `stop_before_pixels=True` for faster processing
![Uploading Screenshot 2026-03-27 at 10.29.49 AM.png…]()
… everything in SQLits and Logs everything