### PR TITLE
Add pre-commit config for code quality checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: check-merge-conflict
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.8
+    hooks:
+      # Linter: checks for syntax errors, unused imports, etc.
+      - id: ruff-check
+        args: [ --fix ] # Automatically fixes what it can
+      # Formatter: auto-styles code like Black
+      - id: ruff-format


### PR DESCRIPTION
## Summary

- Adds `.pre-commit-config.yaml` with:
  -  five standard hooks from `pre-commit/pre-commit-hooks`
     - Catches trailing whitespace, missing EOF newlines, YAML syntax errors, large files, and merge conflict markers before they land in the repo
   - `ruff-format` and `ruff-check` from `ruff-pre-commit`
      - Linter: checks for syntax errors, unused imports, etc.
      - Formatter: auto-styles code like Black 

## Motivation

Many committed files contain trailing whitespace and other formatting issues, likely from copy-paste. Without automated checks, these slip through review and accumulate over time, adding noise to diffs and requiring more efforts from reviewers.

## Benefits                                                                                                          

- Saves reviewer time
- Consistent, standardized code
- Enforces Python-specific grammar
- Low-friction onboarding

Closes #85