### PR TITLE
Feature/album manager

### DIFF
--- a/dicom-album-env/Scripts/album_manager.py
+++ b/dicom-album-env/Scripts/album_manager.py
@@ -1,0 +1,206 @@
+import uuid
+import logging
+from datetime import datetime, timezone
+ 
+import pandas as pd
+from sqlalchemy import (
+    create_engine, Column, Integer, String, DateTime, Text, Table, ForeignKey
+)
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+ 
+from dicom_indexer import DICOMIndex, Base
+from query_metadata import query_metadata
+ 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+ 
+album_files = Table(
+    "album_files",
+    Base.metadata,
+    Column("album_id", String(36), ForeignKey("albums.album_id")),
+    Column("dicom_id", Integer, ForeignKey("DICOMIndex.id")),
+)
+ 
+class Album(Base):
+    __tablename__ = "albums"
+ 
+    album_id    = Column(String(36), primary_key=True,
+                         default=lambda: str(uuid.uuid4()))
+    name        = Column(String(300), nullable=False)
+    description = Column(Text, nullable=True)
+    query_used  = Column(Text, nullable=True)   # stores the query string for reference
+    created_at  = Column(DateTime,
+                         default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+ 
+    # SQLAlchemy relationship — gives us album.files as a Python list
+    files = relationship("DICOMIndex", secondary=album_files, backref="albums")
+ 
+    def __repr__(self):
+        return f"<Album '{self.name}' | {len(self.files)} file(s) | {self.album_id}>"
+ 
+def load_index_as_dataframe(session):
+    """
+    Load all rows from the DICOMIndex table into a pandas DataFrame.
+    Column names are mapped to match the query_metadata.py field whitelist.
+ 
+    Parameters
+    ----------
+    session : SQLAlchemy session (already open)
+ 
+    Returns
+    -------
+    pd.DataFrame with columns:
+        id, PatientID, Modality, StudyDate, SeriesDescription,
+        AccessionNumber, FilePath, study_uid, series_uid
+    """
+    rows = session.query(DICOMIndex).all()
+ 
+    if not rows:
+        return pd.DataFrame()
+ 
+    data = []
+    for row in rows:
+        data.append({
+            "id":               row.id,
+            # Map to query_metadata's expected field names
+            "PatientID":        row.patient_id or "",
+            "Modality":         row.modality or "",
+            # StudyDate stored as datetime — convert back to YYYYMMDD string
+            # so query_metadata.py can parse it correctly
+            "StudyDate":        row.study_date.strftime("%Y%m%d")
+                                if row.study_date else "",
+            "SeriesDescription": row.series_description or "",
+            # query_metadata expects FilePath, not file_path
+            "FilePath":         row.file_path,
+            # Keep UIDs for reference
+            "study_uid":        row.study_uid or "",
+            "series_uid":       row.series_uid or "",
+        })
+ 
+    return pd.DataFrame(data)
+ 
+def create_album(name, db_path, query, description=None):
+    """
+    Filter the DICOM index using a query string and save the result
+    as a named album in the same SQLite database.
+ 
+    This is the core function of this module. It:
+      1. Loads the SQLite index into a DataFrame
+      2. Passes it through the existing query_metadata engine
+      3. Fetches the matching DICOMIndex rows from SQLAlchemy
+      4. Persists them as a named Album
+ 
+    Parameters
+    ----------
+    name        : str   Album name (required)
+    db_path     : str   Path to the SQLite DB built by dicom_indexer
+    query       : str   Query string using query_metadata syntax e.g.
+                        "Modality == 'CT' and StudyDate > '20200101'"
+    description : str   Optional free-text description
+ 
+    Returns
+    -------
+    Album  The persisted Album object, or None if no files matched.
+ 
+    Raises
+    ------
+    ValueError  If the query string is invalid (from query_metadata)
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)   # creates albums + album_files if missing
+    Session = sessionmaker(bind=engine)
+    session = Session()
+ 
+    try:
+        df = load_index_as_dataframe(session)
+ 
+        if df.empty:
+            logger.warning("Index is empty — run dicom_indexer first.")
+            return None
+        filtered_df = query_metadata(df, query)
+ 
+        if filtered_df.empty:
+            logger.warning("No files matched query: %s", query)
+            return None
+ 
+        logger.info("Query matched %d file(s).", len(filtered_df))
+ 
+        matched_ids   = filtered_df["id"].tolist()
+        matched_files = session.query(DICOMIndex)\
+                               .filter(DICOMIndex.id.in_(matched_ids))\
+                               .all()
+
+        album = Album(
+            name=name,
+            description=description,
+            query_used=query,
+            files=matched_files,
+        )
+ 
+        session.add(album)
+        session.commit()
+        session.refresh(album)
+ 
+        logger.info(
+            "Album '%s' created — %d file(s) — ID: %s",
+            album.name, len(album.files), album.album_id,
+        )
+        return album
+ 
+    except ValueError:
+        raise
+ 
+    except Exception as exc:
+        session.rollback()
+        logger.error("Failed to create album: %s", exc)
+        raise
+ 
+    finally:
+        session.close()
+
+def list_albums(db_path):
+    """
+    Return all albums stored in the database.
+ 
+    Parameters
+    ----------
+    db_path : str  Path to the SQLite DB
+ 
+    Returns
+    -------
+    list of Album objects
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        return session.query(Album).all()
+    finally:
+        session.close()
+
+def get_album(album_id, db_path):
+    """
+    Return a single album by its UUID, or None if not found.
+ 
+    Parameters
+    ----------
+    album_id : str  The UUID string of the album
+    db_path  : str  Path to the SQLite DB
+ 
+    Returns
+    -------
+    Album or None
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        return session.query(Album)\
+                      .filter(Album.album_id == album_id)\
+                      .first()
+    finally:
+        session.close()

--- a/dicom-album-env/Scripts/dicom_indexer.py
+++ b/dicom-album-env/Scripts/dicom_indexer.py
@@ -1,0 +1,125 @@
+import os
+import argparse
+import logging
+from datetime import datetime, timezone
+
+import pydicom
+from pydicom.errors import InvalidDicomError
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+Base = declarative_base()
+
+
+class DICOMIndex(Base):
+    __tablename__ = "DICOMIndex"
+
+    id= Column(Integer, primary_key=True)
+    file_path= Column(String(500), unique=True, nullable=False)
+    patient_id= Column(String(100), index=True)
+    series_description= Column(String(300))
+    study_uid= Column(String(200), index=True)
+    study_date= Column(DateTime)
+    series_uid= Column(String(200))
+    indexed_at= Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+    modality= Column(String(50))
+
+    def __repr__(self):
+        return f"<DICOMIndex {self.file_path}>"
+
+def parse_study_date(raw):
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(str(raw).strip(), "%Y%m%d")
+    except ValueError:
+        return None
+
+def extract_metadata(filepath):
+    try:
+        ds = pydicom.dcmread(filepath, stop_before_pixels=True)
+    except InvalidDicomError:
+        logger.warning("Skipping non-DICOM file: %s", filepath)
+        return None
+    except Exception as exc:
+        logger.warning("Could not read %s — %s", filepath, exc)
+        return None
+
+    return {
+        "file_path": os.path.abspath(filepath),
+        "patient_id": getattr(ds, "PatientID", None),
+        "study_uid": getattr(ds, "StudyInstanceUID", None),
+        "series_uid": getattr(ds, "SeriesInstanceUID", None),
+        "modality": getattr(ds, "Modality", None),
+        "study_date": parse_study_date(getattr(ds, "StudyDate", None)),
+        "series_description": getattr(ds, "SeriesDescription", None),}
+
+def iter_dicom_files(folder):
+    for root, _, files in os.walk(folder):
+        for fname in files:
+            if fname.lower().endswith((".dcm", ".dicom")) or "." not in fname:
+                yield os.path.join(root, fname)
+
+def index_folder(folder, db_path):
+    engine= create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    Session= sessionmaker(bind=engine)
+    session= Session()
+    existing= {row[0] for row in session.query(DICOMIndex.file_path).all()}
+    added= 0
+    skipped= 0
+    failed= 0
+
+    for filepath in iter_dicom_files(folder):
+        abs_path= os.path.abspath(filepath)
+        if abs_path in existing:
+            skipped += 1
+            continue
+        meta= extract_metadata(filepath)
+        if meta is None:
+            failed += 1
+            continue
+        session.add(DICOMIndex(**meta))
+        existing.add(abs_path)
+        added += 1
+        if added % 100 == 0:
+            session.commit()
+            logger.info("Indexed %d files so far ...", added)
+
+    session.commit()
+    session.close()
+    logger.info("Done — added: %d  skipped: %d  failed: %d", added, skipped, failed)
+    logger.info("Database written to: %s", os.path.abspath(db_path))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan a folder of DICOM files and index their metadata into SQLite."
+    )
+    parser.add_argument(
+        "folder",
+        help="Path to the folder containing DICOM files (scanned recursively).",
+    )
+    parser.add_argument(
+        "--db",
+        default="dicom_index.db",
+        help="Output SQLite database file (default: dicom_index.db).",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.folder):
+        logger.error("'%s' is not a valid directory.", args.folder)
+        return
+
+    logger.info("Scanning folder: %s", os.path.abspath(args.folder))
+    index_folder(args.folder, args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_albumManager.py
+++ b/tests/test_albumManager.py
@@ -1,0 +1,209 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'dicom-album-env', 'Scripts'))
+import shutil
+import pytest
+ 
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydicom.data import get_testdata_file
+ 
+from dicom_indexer import index_folder, DICOMIndex, Base
+from album_manager import (
+    Album, create_album, list_albums, get_album, load_index_as_dataframe
+)
+
+ 
+@pytest.fixture
+def sample_dcm():
+    """Real CT DICOM file bundled with pydicom — no external files needed."""
+    return get_testdata_file("CT_small.dcm")
+ 
+ 
+@pytest.fixture
+def indexed_db(tmp_path, sample_dcm):
+    """
+    Builds a fully indexed SQLite DB with one CT DICOM file.
+    This is the same setup as test_dicomIndexer.py — consistent style.
+    """
+    dicom_dir = tmp_path / "dicoms"
+    dicom_dir.mkdir()
+    shutil.copy(sample_dcm, dicom_dir / "CT_small.dcm")
+    db_path = str(tmp_path / "test.db")
+    index_folder(str(dicom_dir), db_path)
+    return db_path
+
+class TestLoadIndexAsDataframe:
+ 
+    def test_returns_dataframe(self, indexed_db):
+        """Should return a pandas DataFrame, not a list or None."""
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        import pandas as pd
+        assert isinstance(df, pd.DataFrame)
+ 
+    def test_dataframe_has_required_columns(self, indexed_db):
+        """
+        Columns must match query_metadata.py's ALLOWED_FIELDS whitelist.
+        If these are missing, the query engine will reject every query.
+        """
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        for col in ["PatientID", "Modality", "StudyDate", "SeriesDescription", "FilePath"]:
+            assert col in df.columns, f"Missing column: {col}"
+ 
+    def test_studydate_is_yyyymmdd_string(self, indexed_db):
+        """
+        query_metadata.py expects StudyDate as YYYYMMDD string.
+        dicom_indexer stores it as datetime — the bridge must convert it.
+        """
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        date_val = df["StudyDate"].iloc[0]
+        assert isinstance(date_val, str)
+        assert len(date_val) == 8
+        assert date_val.isdigit()
+ 
+    def test_empty_db_returns_empty_dataframe(self, tmp_path):
+        """Empty index should return empty DataFrame, not crash."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        assert df.empty
+
+class TestCreateAlbum:
+ 
+    def test_creates_album_for_matching_query(self, indexed_db):
+        """CT_small.dcm is a CT file — querying for CT should find it."""
+        album = create_album("My CT Album", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert album.name == "My CT Album"
+ 
+    def test_album_contains_matched_files(self, indexed_db):
+        """Album must actually contain the matched DICOM files."""
+        album = create_album("Files Test", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert len(album.files) >= 1
+ 
+    def test_album_stores_query_used(self, indexed_db):
+        """
+        The query string is stored on the album so you can see
+        how an album was built later — important for reproducibility.
+        """
+        query = "Modality == 'CT'"
+        album = create_album("Query Test", indexed_db, query=query)
+        assert album is not None
+        assert album.query_used == query
+ 
+    def test_album_has_unique_uuid(self, indexed_db):
+        """Every album must get a different UUID — no collisions."""
+        album1 = create_album("Album A", indexed_db, query="Modality == 'CT'")
+        album2 = create_album("Album B", indexed_db, query="Modality == 'CT'")
+        assert album1.album_id != album2.album_id
+ 
+    def test_album_has_created_at_timestamp(self, indexed_db):
+        """created_at must be set automatically on creation."""
+        album = create_album("Timestamped", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert isinstance(album.created_at, datetime)
+ 
+    def test_description_is_stored(self, indexed_db):
+        """Optional description should be saved correctly."""
+        album = create_album(
+            "Described", indexed_db,
+            query="Modality == 'CT'",
+            description="My test album"
+        )
+        assert album is not None
+        assert album.description == "My test album"
+ 
+    def test_no_match_returns_none(self, indexed_db):
+        """
+        If query matches nothing, return None instead of creating
+        an empty album — empty albums are useless.
+        """
+        album = create_album("Empty", indexed_db, query="Modality == 'MR'")
+        assert album is None
+ 
+    def test_empty_index_returns_none(self, tmp_path):
+        """If the index has no files at all, return None gracefully."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        album = create_album("Nothing", db_path, query="Modality == 'CT'")
+        assert album is None
+ 
+    def test_invalid_query_raises_value_error(self, indexed_db):
+        """
+        query_metadata raises ValueError for bad queries.
+        create_album must not swallow it — let it bubble up
+        so the caller knows the query was wrong.
+        """
+        with pytest.raises(ValueError):
+            create_album("Bad Query", indexed_db, query="InvalidField == 'CT'")
+ 
+    def test_date_range_query_works(self, indexed_db):
+        """
+        Test that the StudyDate YYYYMMDD conversion in load_index_as_dataframe
+        actually allows date range queries to work end-to-end.
+        """
+        album = create_album(
+            "Date Range",
+            indexed_db,
+            query="Modality == 'CT' and StudyDate > '20000101'"
+        )
+        assert album is not None
+ 
+    def test_two_albums_share_same_files(self, indexed_db):
+        """
+        The same DICOM file can belong to multiple albums.
+        This tests the many-to-many relationship works correctly.
+        """
+        album1 = create_album("First",  indexed_db, query="Modality == 'CT'")
+        album2 = create_album("Second", indexed_db, query="Modality == 'CT'")
+        assert album1 is not None
+        assert album2 is not None
+        # Both albums reference the same underlying file
+        assert album1.files[0].file_path == album2.files[0].file_path
+ 
+ 
+# ── Tests: list_albums and get_album ─────────────────────────────────────────
+ 
+class TestListAndGetAlbum:
+ 
+    def test_list_albums_returns_all(self, indexed_db):
+        """list_albums must return every album created."""
+        create_album("Album 1", indexed_db, query="Modality == 'CT'")
+        create_album("Album 2", indexed_db, query="Modality == 'CT'")
+        albums = list_albums(indexed_db)
+        assert len(albums) >= 2
+ 
+    def test_list_albums_empty_db(self, tmp_path):
+        """list_albums on empty DB should return empty list, not crash."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        assert list_albums(db_path) == []
+ 
+    def test_get_album_by_id(self, indexed_db):
+        """get_album must return the correct album by UUID."""
+        album   = create_album("Fetchable", indexed_db, query="Modality == 'CT'")
+        fetched = get_album(album.album_id, indexed_db)
+        assert fetched is not None
+        assert fetched.name == "Fetchable"
+ 
+    def test_get_album_wrong_id_returns_none(self, indexed_db):
+        """get_album with a non-existent ID must return None, not crash."""
+        result = get_album("00000000-0000-0000-0000-000000000000", indexed_db)
+        assert result is None
+ 

--- a/tests/test_dicomIndexer.py
+++ b/tests/test_dicomIndexer.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dicom-album-env", "Scripts"))
+
+from dicom_indexer import extract_metadata, parse_study_date, index_folder, DICOMIndex
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydicom.data import get_testdata_file
+
+@pytest.fixture
+def sample_dcm():
+    return get_testdata_file("CT_small.dcm")
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_index.db")
+
+@pytest.fixture
+def tmp_dicom_dir(tmp_path, sample_dcm):
+    import shutil
+    shutil.copy(sample_dcm, tmp_path / "CT_small.dcm")
+    (tmp_path / "not_dicom.txt").write_text("this is not a dicom file")
+    return str(tmp_path)
+
+class TestParseStudyDate:
+    def test_valid_date_string(self):
+        result = parse_study_date("20200115")
+        assert result is not None
+        assert result.year == 2020
+    def test_none_input(self):
+        assert parse_study_date(None) is None
+    def test_empty_string(self):
+        assert parse_study_date("") is None
+    def test_invalid_format(self):
+        assert parse_study_date("not-a-date") is None
+
+class TestExtractMetadata:
+    def test_returns_dict_for_valid_dicom(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta is not None
+        assert isinstance(meta, dict)
+    def test_returns_none_for_non_dicom(self, tmp_path):
+        fake = tmp_path / "fake.dcm"
+        fake.write_text("this is not dicom content")
+        assert extract_metadata(str(fake)) is None
+    def test_contains_required_keys(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        for key in ["file_path", "patient_id", "study_uid", "modality", "study_date"]:
+            assert key in meta
+    def test_file_path_is_absolute(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert os.path.isabs(meta["file_path"])
+    def test_modality_is_ct(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta["modality"] == "CT"
+
+class TestIndexFolder:
+    def test_indexes_dicom_file(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count >= 1
+    def test_skips_non_dicom_files(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_no_duplicates_on_reindex(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_modality_stored_correctly(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        record = session.query(DICOMIndex).first()
+        session.close()
+        assert record.modality == "CT"


### PR DESCRIPTION
This PR adds `album_manager.py` which connects two existing but disconnected parts of the codebase — the DICOM metadata indexer (PR #81) and the existing `query_metadata.py` engine — to finally enable actual album creation.

## What this does

The indexer from PR #81 stores DICOM metadata in SQLite. The existing `query_metadata.py` filters metadata using a safe query engine. But neither was connected to album creation. This PR bridges them.

## Pipeline implemented

```
DICOM folder
    ↓ dicom_indexer.py (PR #81)
SQLite database
    ↓ load_index_as_dataframe()
pandas DataFrame
    ↓ query_metadata.py (existing)
filtered results
    ↓ create_album()
named Album persisted in SQLite
```

## Features implemented
- Loads SQLite index into a DataFrame, mapping column names to match `query_metadata.py`'s field whitelist
- Converts `StudyDate` from `datetime` (stored by indexer) back to `YYYYMMDD` string (expected by query engine) — handled explicitly in `load_index_as_dataframe()`
- Filters DICOM files using query strings like `"Modality == 'CT' and StudyDate > '20200101'"`
- Persists matched files as a named Album with a unique UUID, timestamp, and the query string stored for reproducibility
- Many-to-many relationship between albums and DICOM files — one file can belong to multiple albums
- Invalid queries raise `ValueError` from `query_metadata` — no silent failures
- Returns `None` gracefully if no files match instead of creating empty albums

## Database fields stored (Album)
- `album_id` (UUID)
- `name`
- `description`
- `query_used`
- `created_at`
- many-to-many link to `DICOMIndex` via `album_files` join table

## Test plan

19 tests across 3 classes — all passing:
- `TestLoadIndexAsDataframe` — verifies the bridge works correctly including the `StudyDate` conversion
- `TestCreateAlbum` — full pipeline end-to-end including date range queries, empty index handling, invalid query rejection, and many-to-many file sharing
- `TestListAndGetAlbum` — list all albums, fetch by UUID, handle missing ID

<img width="1385" height="466" alt="Screenshot 2026-03-29 at 11 27 57 PM" src="https://github.com/user-attachments/assets/823244c1-4c2b-4b1b-80a5-4631c0627ff2" />


## Notes
- Used `SQLAlchemy` for database operations
- Used `pydicom` bundled test data (`CT_small.dcm`) for tests — no external files needed
- Builds directly on PR #81 and existing `query_metadata.py`

Relates to issue #13 (shareable albums).
