### PR TITLE
Feature/album api.py

### DIFF
--- a/dicom-album-env/Scripts/album_api.py
+++ b/dicom-album-env/Scripts/album_api.py
@@ -1,0 +1,196 @@
+import os
+import sys
+ 
+from flask import Flask, request, jsonify
+sys.path.insert(0, os.path.join(os.path.dirname(__file__)))
+ 
+from dicom_indexer import index_folder
+from album_manager import create_album, list_albums, get_album
+ 
+app = Flask(__name__)
+DEFAULT_DB = os.environ.get("DICOM_DB_PATH", "dicom_index.db")
+ 
+@app.route("/index", methods=["POST"])
+def index():
+    """
+    Scan a local folder and index all DICOM files into SQLite.
+    Request body (JSON):
+        {
+            "folder": "/path/to/dicom/files",   # required
+            "db_path": "dicom_index.db"          # optional, uses default if omitted
+        }
+ 
+    Response:
+        200 — { "status": "success", "message": "..." }
+        400 — { "error": "..." }
+        500 — { "error": "..." }
+    """
+    data = request.get_json(silent=True)
+ 
+    if not data or "folder" not in data:
+        return jsonify({"error": "'folder' is required in request body"}), 400
+ 
+    folder  = data["folder"]
+    db_path = data.get("db_path", DEFAULT_DB)
+ 
+    if not os.path.isdir(folder):
+        return jsonify({"error": f"'{folder}' is not a valid directory"}), 400
+ 
+    try:
+        index_folder(folder, db_path)
+        return jsonify({
+            "status":  "success",
+            "message": f"Indexed DICOM files from '{folder}' into '{db_path}'",
+        }), 200
+ 
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+@app.route("/albums", methods=["POST"])
+def create():
+    """
+    Create a named album by querying the DICOM index.
+ 
+    Request body (JSON):
+        {
+            "name":        "My CT Album",               # required
+            "query":       "Modality == 'CT'",           # required
+            "description": "All CT scans from 2023",    # optional
+            "db_path":     "dicom_index.db"             # optional
+        }
+ 
+    Query syntax (from query_metadata.py):
+        "Modality == 'CT'"
+        "Modality == 'CT' and StudyDate > '20200101'"
+        "Modality in ['CT', 'MR']"
+ 
+    Response:
+        201 — { "status": "success", "album": { ... } }
+        400 — { "error": "..." }
+        404 — { "error": "No files matched" }
+        500 — { "error": "..." }
+    """
+    data = request.get_json(silent=True)
+ 
+    if not data:
+        return jsonify({"error": "Request body must be JSON"}), 400
+ 
+    if "name" not in data:
+        return jsonify({"error": "'name' is required"}), 400
+ 
+    if "query" not in data:
+        return jsonify({"error": "'query' is required"}), 400
+ 
+    name        = data["name"]
+    query       = data["query"]
+    description = data.get("description")
+    db_path     = data.get("db_path", DEFAULT_DB)
+ 
+    try:
+        album = create_album(
+            name=name,
+            db_path=db_path,
+            query=query,
+            description=description,
+        )
+ 
+        if album is None:
+            return jsonify({
+                "error": f"No DICOM files matched query: {query}"
+            }), 404
+ 
+        return jsonify({
+            "status": "success",
+            "album": {
+                "album_id":    album.album_id,
+                "name":        album.name,
+                "description": album.description,
+                "query_used":  album.query_used,
+                "created_at":  album.created_at.isoformat(),
+                "file_count":  len(album.files),
+            },
+        }), 201
+ 
+    except ValueError as exc:
+        # Invalid query string from query_metadata
+        return jsonify({"error": f"Invalid query: {exc}"}), 400
+ 
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+ 
+ 
+# ── GET /albums ───────────────────────────────────────────────────────────────
+@app.route("/albums", methods=["GET"])
+def list_all():
+    """
+    List all albums stored in the database.
+ 
+    Query params:
+        db_path — optional, path to SQLite DB
+ 
+    Response:
+        200 — { "status": "success", "count": N, "albums": [ ... ] }
+        500 — { "error": "..." }
+    """
+    db_path = request.args.get("db_path", DEFAULT_DB)
+ 
+    try:
+        albums = list_albums(db_path)
+        return jsonify({
+            "status": "success",
+            "count":  len(albums),
+            "albums": [
+                {
+                    "album_id":   a.album_id,
+                    "name":       a.name,
+                    "description": a.description,
+                    "query_used": a.query_used,
+                    "created_at": a.created_at.isoformat(),
+                    "file_count": len(a.files),
+                }
+                for a in albums
+            ],
+        }), 200
+ 
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+ 
+ 
+# ── GET /albums/<album_id> ────────────────────────────────────────────────────
+@app.route("/albums/<album_id>", methods=["GET"])
+def get_one(album_id):
+    """
+    Get a single album by its UUID, including all file paths it contains.
+ 
+    Response:
+        200 — { "status": "success", "album": { ..., "files": [...] } }
+        404 — { "error": "Album not found" }
+        500 — { "error": "..." }
+    """
+    db_path = request.args.get("db_path", DEFAULT_DB)
+ 
+    try:
+        album = get_album(album_id, db_path)
+ 
+        if album is None:
+            return jsonify({"error": f"Album '{album_id}' not found"}), 404
+ 
+        return jsonify({
+            "status": "success",
+            "album": {
+                "album_id":    album.album_id,
+                "name":        album.name,
+                "description": album.description,
+                "query_used":  album.query_used,
+                "created_at":  album.created_at.isoformat(),
+                "file_count":  len(album.files),
+                "files":       [f.file_path for f in album.files],
+            },
+        }), 200
+ 
+    except Exception as exc:
+        return jsonify({"error": str(exc)}), 500
+ 
+ 
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)
+ 

--- a/dicom-album-env/Scripts/album_manager.py
+++ b/dicom-album-env/Scripts/album_manager.py
@@ -1,0 +1,206 @@
+import uuid
+import logging
+from datetime import datetime, timezone
+ 
+import pandas as pd
+from sqlalchemy import (
+    create_engine, Column, Integer, String, DateTime, Text, Table, ForeignKey
+)
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship
+ 
+from dicom_indexer import DICOMIndex, Base
+from query_metadata import query_metadata
+ 
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+ 
+album_files = Table(
+    "album_files",
+    Base.metadata,
+    Column("album_id", String(36), ForeignKey("albums.album_id")),
+    Column("dicom_id", Integer, ForeignKey("DICOMIndex.id")),
+)
+ 
+class Album(Base):
+    __tablename__ = "albums"
+ 
+    album_id    = Column(String(36), primary_key=True,
+                         default=lambda: str(uuid.uuid4()))
+    name        = Column(String(300), nullable=False)
+    description = Column(Text, nullable=True)
+    query_used  = Column(Text, nullable=True)   # stores the query string for reference
+    created_at  = Column(DateTime,
+                         default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+ 
+    # SQLAlchemy relationship — gives us album.files as a Python list
+    files = relationship("DICOMIndex", secondary=album_files, backref="albums")
+ 
+    def __repr__(self):
+        return f"<Album '{self.name}' | {len(self.files)} file(s) | {self.album_id}>"
+ 
+def load_index_as_dataframe(session):
+    """
+    Load all rows from the DICOMIndex table into a pandas DataFrame.
+    Column names are mapped to match the query_metadata.py field whitelist.
+ 
+    Parameters
+    ----------
+    session : SQLAlchemy session (already open)
+ 
+    Returns
+    -------
+    pd.DataFrame with columns:
+        id, PatientID, Modality, StudyDate, SeriesDescription,
+        AccessionNumber, FilePath, study_uid, series_uid
+    """
+    rows = session.query(DICOMIndex).all()
+ 
+    if not rows:
+        return pd.DataFrame()
+ 
+    data = []
+    for row in rows:
+        data.append({
+            "id":               row.id,
+            # Map to query_metadata's expected field names
+            "PatientID":        row.patient_id or "",
+            "Modality":         row.modality or "",
+            # StudyDate stored as datetime — convert back to YYYYMMDD string
+            # so query_metadata.py can parse it correctly
+            "StudyDate":        row.study_date.strftime("%Y%m%d")
+                                if row.study_date else "",
+            "SeriesDescription": row.series_description or "",
+            # query_metadata expects FilePath, not file_path
+            "FilePath":         row.file_path,
+            # Keep UIDs for reference
+            "study_uid":        row.study_uid or "",
+            "series_uid":       row.series_uid or "",
+        })
+ 
+    return pd.DataFrame(data)
+ 
+def create_album(name, db_path, query, description=None):
+    """
+    Filter the DICOM index using a query string and save the result
+    as a named album in the same SQLite database.
+ 
+    This is the core function of this module. It:
+      1. Loads the SQLite index into a DataFrame
+      2. Passes it through the existing query_metadata engine
+      3. Fetches the matching DICOMIndex rows from SQLAlchemy
+      4. Persists them as a named Album
+ 
+    Parameters
+    ----------
+    name        : str   Album name (required)
+    db_path     : str   Path to the SQLite DB built by dicom_indexer
+    query       : str   Query string using query_metadata syntax e.g.
+                        "Modality == 'CT' and StudyDate > '20200101'"
+    description : str   Optional free-text description
+ 
+    Returns
+    -------
+    Album  The persisted Album object, or None if no files matched.
+ 
+    Raises
+    ------
+    ValueError  If the query string is invalid (from query_metadata)
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)   # creates albums + album_files if missing
+    Session = sessionmaker(bind=engine)
+    session = Session()
+ 
+    try:
+        df = load_index_as_dataframe(session)
+ 
+        if df.empty:
+            logger.warning("Index is empty — run dicom_indexer first.")
+            return None
+        filtered_df = query_metadata(df, query)
+ 
+        if filtered_df.empty:
+            logger.warning("No files matched query: %s", query)
+            return None
+ 
+        logger.info("Query matched %d file(s).", len(filtered_df))
+ 
+        matched_ids   = filtered_df["id"].tolist()
+        matched_files = session.query(DICOMIndex)\
+                               .filter(DICOMIndex.id.in_(matched_ids))\
+                               .all()
+
+        album = Album(
+            name=name,
+            description=description,
+            query_used=query,
+            files=matched_files,
+        )
+ 
+        session.add(album)
+        session.commit()
+        session.refresh(album)
+ 
+        logger.info(
+            "Album '%s' created — %d file(s) — ID: %s",
+            album.name, len(album.files), album.album_id,
+        )
+        return album
+ 
+    except ValueError:
+        raise
+ 
+    except Exception as exc:
+        session.rollback()
+        logger.error("Failed to create album: %s", exc)
+        raise
+ 
+    finally:
+        session.close()
+
+def list_albums(db_path):
+    """
+    Return all albums stored in the database.
+ 
+    Parameters
+    ----------
+    db_path : str  Path to the SQLite DB
+ 
+    Returns
+    -------
+    list of Album objects
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        return session.query(Album).all()
+    finally:
+        session.close()
+
+def get_album(album_id, db_path):
+    """
+    Return a single album by its UUID, or None if not found.
+ 
+    Parameters
+    ----------
+    album_id : str  The UUID string of the album
+    db_path  : str  Path to the SQLite DB
+ 
+    Returns
+    -------
+    Album or None
+    """
+    engine  = create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        return session.query(Album)\
+                      .filter(Album.album_id == album_id)\
+                      .first()
+    finally:
+        session.close()

--- a/dicom-album-env/Scripts/album_manager.py
+++ b/dicom-album-env/Scripts/album_manager.py
@@ -1,134 +1,99 @@
 import uuid
 import logging
 from datetime import datetime, timezone
- 
+
 import pandas as pd
 from sqlalchemy import (
     create_engine, Column, Integer, String, DateTime, Text, Table, ForeignKey
 )
-from sqlalchemy.orm import declarative_base, sessionmaker, relationship
- 
+from sqlalchemy.orm import declarative_base, sessionmaker, relationship, joinedload
+
 from dicom_indexer import DICOMIndex, Base
 from query_metadata import query_metadata
- 
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s  %(levelname)s  %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )
 logger = logging.getLogger(__name__)
- 
+
 album_files = Table(
     "album_files",
     Base.metadata,
     Column("album_id", String(36), ForeignKey("albums.album_id")),
     Column("dicom_id", Integer, ForeignKey("DICOMIndex.id")),
 )
- 
+
 class Album(Base):
     __tablename__ = "albums"
- 
+
     album_id    = Column(String(36), primary_key=True,
                          default=lambda: str(uuid.uuid4()))
     name        = Column(String(300), nullable=False)
     description = Column(Text, nullable=True)
-    query_used  = Column(Text, nullable=True)   # stores the query string for reference
+    query_used  = Column(Text, nullable=True)
     created_at  = Column(DateTime,
                          default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
- 
-    # SQLAlchemy relationship — gives us album.files as a Python list
+
     files = relationship("DICOMIndex", secondary=album_files, backref="albums")
- 
+
     def __repr__(self):
         return f"<Album '{self.name}' | {len(self.files)} file(s) | {self.album_id}>"
- 
+
+
 def load_index_as_dataframe(session):
     """
     Load all rows from the DICOMIndex table into a pandas DataFrame.
     Column names are mapped to match the query_metadata.py field whitelist.
- 
-    Parameters
-    ----------
-    session : SQLAlchemy session (already open)
- 
-    Returns
-    -------
-    pd.DataFrame with columns:
-        id, PatientID, Modality, StudyDate, SeriesDescription,
-        AccessionNumber, FilePath, study_uid, series_uid
     """
     rows = session.query(DICOMIndex).all()
- 
+
     if not rows:
         return pd.DataFrame()
- 
+
     data = []
     for row in rows:
         data.append({
-            "id":               row.id,
-            # Map to query_metadata's expected field names
-            "PatientID":        row.patient_id or "",
-            "Modality":         row.modality or "",
-            # StudyDate stored as datetime — convert back to YYYYMMDD string
-            # so query_metadata.py can parse it correctly
-            "StudyDate":        row.study_date.strftime("%Y%m%d")
-                                if row.study_date else "",
+            "id":                row.id,
+            "PatientID":         row.patient_id or "",
+            "Modality":          row.modality or "",
+            "StudyDate":         row.study_date.strftime("%Y%m%d")
+                                 if row.study_date else "",
             "SeriesDescription": row.series_description or "",
-            # query_metadata expects FilePath, not file_path
-            "FilePath":         row.file_path,
-            # Keep UIDs for reference
-            "study_uid":        row.study_uid or "",
-            "series_uid":       row.series_uid or "",
+            "FilePath":          row.file_path,
+            "study_uid":         row.study_uid or "",
+            "series_uid":        row.series_uid or "",
         })
- 
+
     return pd.DataFrame(data)
- 
+
+
 def create_album(name, db_path, query, description=None):
     """
     Filter the DICOM index using a query string and save the result
     as a named album in the same SQLite database.
- 
-    This is the core function of this module. It:
-      1. Loads the SQLite index into a DataFrame
-      2. Passes it through the existing query_metadata engine
-      3. Fetches the matching DICOMIndex rows from SQLAlchemy
-      4. Persists them as a named Album
- 
-    Parameters
-    ----------
-    name        : str   Album name (required)
-    db_path     : str   Path to the SQLite DB built by dicom_indexer
-    query       : str   Query string using query_metadata syntax e.g.
-                        "Modality == 'CT' and StudyDate > '20200101'"
-    description : str   Optional free-text description
- 
-    Returns
-    -------
-    Album  The persisted Album object, or None if no files matched.
- 
-    Raises
-    ------
-    ValueError  If the query string is invalid (from query_metadata)
     """
     engine  = create_engine(f"sqlite:///{db_path}", echo=False)
-    Base.metadata.create_all(engine)   # creates albums + album_files if missing
+    Base.metadata.create_all(engine)
     Session = sessionmaker(bind=engine)
     session = Session()
- 
+
     try:
         df = load_index_as_dataframe(session)
- 
+
         if df.empty:
             logger.warning("Index is empty — run dicom_indexer first.")
             return None
+
         filtered_df = query_metadata(df, query)
- 
+
         if filtered_df.empty:
             logger.warning("No files matched query: %s", query)
             return None
- 
+
         logger.info("Query matched %d file(s).", len(filtered_df))
- 
+
         matched_ids   = filtered_df["id"].tolist()
         matched_files = session.query(DICOMIndex)\
                                .filter(DICOMIndex.id.in_(matched_ids))\
@@ -140,67 +105,67 @@ def create_album(name, db_path, query, description=None):
             query_used=query,
             files=matched_files,
         )
- 
+
         session.add(album)
         session.commit()
         session.refresh(album)
- 
+
+        # Access files while session is still open, then detach
+        _ = len(album.files)
+        session.expunge_all()
+
         logger.info(
             "Album '%s' created — %d file(s) — ID: %s",
             album.name, len(album.files), album.album_id,
         )
         return album
- 
+
     except ValueError:
         raise
- 
+
     except Exception as exc:
         session.rollback()
         logger.error("Failed to create album: %s", exc)
         raise
- 
+
     finally:
         session.close()
+
 
 def list_albums(db_path):
     """
-    Return all albums stored in the database.
- 
-    Parameters
-    ----------
-    db_path : str  Path to the SQLite DB
- 
-    Returns
-    -------
-    list of Album objects
+    Return all albums stored in the database with files eagerly loaded.
     """
     engine  = create_engine(f"sqlite:///{db_path}", echo=False)
     Base.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
     try:
-        return session.query(Album).all()
+        albums = session.query(Album)\
+                        .options(joinedload(Album.files))\
+                        .all()
+        for a in albums:
+            _ = len(a.files)
+        session.expunge_all()
+        return albums
     finally:
         session.close()
 
+
 def get_album(album_id, db_path):
     """
-    Return a single album by its UUID, or None if not found.
- 
-    Parameters
-    ----------
-    album_id : str  The UUID string of the album
-    db_path  : str  Path to the SQLite DB
- 
-    Returns
-    -------
-    Album or None
+    Return a single album by its UUID with files eagerly loaded, or None.
     """
     engine  = create_engine(f"sqlite:///{db_path}", echo=False)
     Base.metadata.create_all(engine)
     session = sessionmaker(bind=engine)()
     try:
-        return session.query(Album)\
-                      .filter(Album.album_id == album_id)\
-                      .first()
+        album = session.query(Album)\
+                       .options(joinedload(Album.files))\
+                       .filter(Album.album_id == album_id)\
+                       .first()
+        if album:
+            _ = len(album.files)
+            session.expunge_all()
+        return album
     finally:
         session.close()

--- a/dicom-album-env/Scripts/dicom_indexer.py
+++ b/dicom-album-env/Scripts/dicom_indexer.py
@@ -1,0 +1,125 @@
+import os
+import argparse
+import logging
+from datetime import datetime, timezone
+
+import pydicom
+from pydicom.errors import InvalidDicomError
+from sqlalchemy import create_engine, Column, Integer, String, DateTime
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s  %(levelname)s  %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+Base = declarative_base()
+
+
+class DICOMIndex(Base):
+    __tablename__ = "DICOMIndex"
+
+    id= Column(Integer, primary_key=True)
+    file_path= Column(String(500), unique=True, nullable=False)
+    patient_id= Column(String(100), index=True)
+    series_description= Column(String(300))
+    study_uid= Column(String(200), index=True)
+    study_date= Column(DateTime)
+    series_uid= Column(String(200))
+    indexed_at= Column(DateTime, default=lambda: datetime.now(timezone.utc).replace(tzinfo=None))
+    modality= Column(String(50))
+
+    def __repr__(self):
+        return f"<DICOMIndex {self.file_path}>"
+
+def parse_study_date(raw):
+    if not raw:
+        return None
+    try:
+        return datetime.strptime(str(raw).strip(), "%Y%m%d")
+    except ValueError:
+        return None
+
+def extract_metadata(filepath):
+    try:
+        ds = pydicom.dcmread(filepath, stop_before_pixels=True)
+    except InvalidDicomError:
+        logger.warning("Skipping non-DICOM file: %s", filepath)
+        return None
+    except Exception as exc:
+        logger.warning("Could not read %s — %s", filepath, exc)
+        return None
+
+    return {
+        "file_path": os.path.abspath(filepath),
+        "patient_id": getattr(ds, "PatientID", None),
+        "study_uid": getattr(ds, "StudyInstanceUID", None),
+        "series_uid": getattr(ds, "SeriesInstanceUID", None),
+        "modality": getattr(ds, "Modality", None),
+        "study_date": parse_study_date(getattr(ds, "StudyDate", None)),
+        "series_description": getattr(ds, "SeriesDescription", None),}
+
+def iter_dicom_files(folder):
+    for root, _, files in os.walk(folder):
+        for fname in files:
+            if fname.lower().endswith((".dcm", ".dicom")) or "." not in fname:
+                yield os.path.join(root, fname)
+
+def index_folder(folder, db_path):
+    engine= create_engine(f"sqlite:///{db_path}", echo=False)
+    Base.metadata.create_all(engine)
+    Session= sessionmaker(bind=engine)
+    session= Session()
+    existing= {row[0] for row in session.query(DICOMIndex.file_path).all()}
+    added= 0
+    skipped= 0
+    failed= 0
+
+    for filepath in iter_dicom_files(folder):
+        abs_path= os.path.abspath(filepath)
+        if abs_path in existing:
+            skipped += 1
+            continue
+        meta= extract_metadata(filepath)
+        if meta is None:
+            failed += 1
+            continue
+        session.add(DICOMIndex(**meta))
+        existing.add(abs_path)
+        added += 1
+        if added % 100 == 0:
+            session.commit()
+            logger.info("Indexed %d files so far ...", added)
+
+    session.commit()
+    session.close()
+    logger.info("Done — added: %d  skipped: %d  failed: %d", added, skipped, failed)
+    logger.info("Database written to: %s", os.path.abspath(db_path))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Scan a folder of DICOM files and index their metadata into SQLite."
+    )
+    parser.add_argument(
+        "folder",
+        help="Path to the folder containing DICOM files (scanned recursively).",
+    )
+    parser.add_argument(
+        "--db",
+        default="dicom_index.db",
+        help="Output SQLite database file (default: dicom_index.db).",
+    )
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.folder):
+        logger.error("'%s' is not a valid directory.", args.folder)
+        return
+
+    logger.info("Scanning folder: %s", os.path.abspath(args.folder))
+    index_folder(args.folder, args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_albumApi.py
+++ b/tests/test_albumApi.py
@@ -1,0 +1,239 @@
+import os
+import sys
+import json
+import shutil
+import pytest
+ 
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'dicom-album-env', 'Scripts'))
+ 
+from pydicom.data import get_testdata_file
+from dicom_indexer import index_folder
+from album_api import app
+
+@pytest.fixture
+def client(tmp_path):
+    """
+    Flask test client with a real indexed SQLite DB.
+    Sets DICOM_DB_PATH so all endpoints use the temp DB.
+    """
+    # Build a real indexed DB using CT_small.dcm
+    sample_dcm = get_testdata_file("CT_small.dcm")
+    dicom_dir  = tmp_path / "dicoms"
+    dicom_dir.mkdir()
+    shutil.copy(sample_dcm, dicom_dir / "CT_small.dcm")
+ 
+    db_path = str(tmp_path / "test.db")
+    index_folder(str(dicom_dir), db_path)
+ 
+    app.config["TESTING"] = True
+    os.environ["DICOM_DB_PATH"] = db_path
+ 
+    with app.test_client() as client:
+        yield client, db_path
+ 
+    # Cleanup env var
+    os.environ.pop("DICOM_DB_PATH", None)
+ 
+ 
+@pytest.fixture
+def empty_client(tmp_path):
+    """Flask test client with an empty (un-indexed) DB."""
+    db_path = str(tmp_path / "empty.db")
+    app.config["TESTING"] = True
+    os.environ["DICOM_DB_PATH"] = db_path
+ 
+    with app.test_client() as client:
+        yield client, db_path
+ 
+    os.environ.pop("DICOM_DB_PATH", None)
+ 
+class TestIndexEndpoint:
+ 
+    def test_index_valid_folder(self, client, tmp_path):
+        """Should index a valid folder and return success."""
+        c, db_path = client
+        sample_dcm = get_testdata_file("CT_small.dcm")
+        folder = str(tmp_path / "dicoms2")
+        os.makedirs(folder)
+        shutil.copy(sample_dcm, os.path.join(folder, "CT.dcm"))
+ 
+        resp = c.post("/index", json={"folder": folder, "db_path": db_path})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "success"
+ 
+    def test_index_missing_folder_param(self, client):
+        """Should return 400 if folder is missing."""
+        c, _ = client
+        resp = c.post("/index", json={})
+        assert resp.status_code == 400
+        assert "error" in resp.get_json()
+ 
+    def test_index_invalid_folder_path(self, client):
+        """Should return 400 if folder path does not exist."""
+        c, db_path = client
+        resp = c.post("/index", json={"folder": "/nonexistent/path", "db_path": db_path})
+        assert resp.status_code == 400
+ 
+    def test_index_no_body(self, client):
+        """Should return 400 if no JSON body sent."""
+        c, _ = client
+        resp = c.post("/index")
+        assert resp.status_code == 400
+ 
+class TestCreateAlbumEndpoint:
+ 
+    def test_create_album_success(self, client):
+        """Should create album and return 201 with album details."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":    "My CT Album",
+            "query":   "Modality == 'CT'",
+            "db_path": db_path,
+        })
+        assert resp.status_code == 201
+        data = resp.get_json()
+        assert data["status"] == "success"
+        assert data["album"]["name"] == "My CT Album"
+        assert data["album"]["file_count"] >= 1
+ 
+    def test_create_album_stores_query(self, client):
+        """query_used should be stored on the album."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":    "Query Test",
+            "query":   "Modality == 'CT'",
+            "db_path": db_path,
+        })
+        assert resp.status_code == 201
+        assert resp.get_json()["album"]["query_used"] == "Modality == 'CT'"
+ 
+    def test_create_album_with_description(self, client):
+        """Optional description should be returned in response."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":        "Described Album",
+            "query":       "Modality == 'CT'",
+            "description": "Test description",
+            "db_path":     db_path,
+        })
+        assert resp.status_code == 201
+        assert resp.get_json()["album"]["description"] == "Test description"
+ 
+    def test_create_album_no_match_returns_404(self, client):
+        """Should return 404 if query matches no files."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":    "Empty",
+            "query":   "Modality == 'MR'",
+            "db_path": db_path,
+        })
+        assert resp.status_code == 404
+ 
+    def test_create_album_invalid_query_returns_400(self, client):
+        """Should return 400 for invalid query string."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":    "Bad",
+            "query":   "InvalidField == 'CT'",
+            "db_path": db_path,
+        })
+        assert resp.status_code == 400
+ 
+    def test_create_album_missing_name_returns_400(self, client):
+        """Should return 400 if name is missing."""
+        c, db_path = client
+        resp = c.post("/albums", json={"query": "Modality == 'CT'", "db_path": db_path})
+        assert resp.status_code == 400
+ 
+    def test_create_album_missing_query_returns_400(self, client):
+        """Should return 400 if query is missing."""
+        c, db_path = client
+        resp = c.post("/albums", json={"name": "No Query", "db_path": db_path})
+        assert resp.status_code == 400
+ 
+    def test_create_album_returns_uuid(self, client):
+        """Response must include a valid album_id UUID."""
+        c, db_path = client
+        resp = c.post("/albums", json={
+            "name":    "UUID Test",
+            "query":   "Modality == 'CT'",
+            "db_path": db_path,
+        })
+        assert resp.status_code == 201
+        album_id = resp.get_json()["album"]["album_id"]
+        assert len(album_id) == 36   # UUID format: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+ 
+ 
+# ── GET /albums ───────────────────────────────────────────────────────────────
+ 
+class TestListAlbumsEndpoint:
+ 
+    def test_list_albums_returns_all(self, client):
+        """Should return all created albums."""
+        c, db_path = client
+        c.post("/albums", json={"name": "A1", "query": "Modality == 'CT'", "db_path": db_path})
+        c.post("/albums", json={"name": "A2", "query": "Modality == 'CT'", "db_path": db_path})
+ 
+        resp = c.get(f"/albums?db_path={db_path}")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["count"] >= 2
+ 
+    def test_list_albums_empty_returns_zero(self, empty_client):
+        """Should return count 0 on empty DB."""
+        c, db_path = empty_client
+        resp = c.get(f"/albums?db_path={db_path}")
+        assert resp.status_code == 200
+        assert resp.get_json()["count"] == 0
+ 
+    def test_list_albums_response_structure(self, client):
+        """Each album in list should have required fields."""
+        c, db_path = client
+        c.post("/albums", json={"name": "Struct", "query": "Modality == 'CT'", "db_path": db_path})
+ 
+        resp = c.get(f"/albums?db_path={db_path}")
+        album = resp.get_json()["albums"][0]
+        for key in ["album_id", "name", "query_used", "created_at", "file_count"]:
+            assert key in album
+ 
+ 
+# ── GET /albums/<album_id> ────────────────────────────────────────────────────
+ 
+class TestGetAlbumEndpoint:
+ 
+    def test_get_album_by_id(self, client):
+        """Should return correct album by UUID."""
+        c, db_path = client
+        create_resp = c.post("/albums", json={
+            "name":    "Fetchable",
+            "query":   "Modality == 'CT'",
+            "db_path": db_path,
+        })
+        album_id = create_resp.get_json()["album"]["album_id"]
+ 
+        resp = c.get(f"/albums/{album_id}?db_path={db_path}")
+        assert resp.status_code == 200
+        assert resp.get_json()["album"]["name"] == "Fetchable"
+ 
+    def test_get_album_includes_file_paths(self, client):
+        """Response should include list of file paths."""
+        c, db_path = client
+        create_resp = c.post("/albums", json={
+            "name":    "Files",
+            "query":   "Modality == 'CT'",
+            "db_path": db_path,
+        })
+        album_id = create_resp.get_json()["album"]["album_id"]
+ 
+        resp = c.get(f"/albums/{album_id}?db_path={db_path}")
+        data = resp.get_json()
+        assert "files" in data["album"]
+        assert len(data["album"]["files"]) >= 1
+ 
+    def test_get_album_wrong_id_returns_404(self, client):
+        """Should return 404 for non-existent album ID."""
+        c, db_path = client
+        resp = c.get(f"/albums/00000000-0000-0000-0000-000000000000?db_path={db_path}")
+        assert resp.status_code == 404
+ 

--- a/tests/test_albumManager.py
+++ b/tests/test_albumManager.py
@@ -1,0 +1,209 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'dicom-album-env', 'Scripts'))
+import shutil
+import pytest
+ 
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydicom.data import get_testdata_file
+ 
+from dicom_indexer import index_folder, DICOMIndex, Base
+from album_manager import (
+    Album, create_album, list_albums, get_album, load_index_as_dataframe
+)
+
+ 
+@pytest.fixture
+def sample_dcm():
+    """Real CT DICOM file bundled with pydicom — no external files needed."""
+    return get_testdata_file("CT_small.dcm")
+ 
+ 
+@pytest.fixture
+def indexed_db(tmp_path, sample_dcm):
+    """
+    Builds a fully indexed SQLite DB with one CT DICOM file.
+    This is the same setup as test_dicomIndexer.py — consistent style.
+    """
+    dicom_dir = tmp_path / "dicoms"
+    dicom_dir.mkdir()
+    shutil.copy(sample_dcm, dicom_dir / "CT_small.dcm")
+    db_path = str(tmp_path / "test.db")
+    index_folder(str(dicom_dir), db_path)
+    return db_path
+
+class TestLoadIndexAsDataframe:
+ 
+    def test_returns_dataframe(self, indexed_db):
+        """Should return a pandas DataFrame, not a list or None."""
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        import pandas as pd
+        assert isinstance(df, pd.DataFrame)
+ 
+    def test_dataframe_has_required_columns(self, indexed_db):
+        """
+        Columns must match query_metadata.py's ALLOWED_FIELDS whitelist.
+        If these are missing, the query engine will reject every query.
+        """
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        for col in ["PatientID", "Modality", "StudyDate", "SeriesDescription", "FilePath"]:
+            assert col in df.columns, f"Missing column: {col}"
+ 
+    def test_studydate_is_yyyymmdd_string(self, indexed_db):
+        """
+        query_metadata.py expects StudyDate as YYYYMMDD string.
+        dicom_indexer stores it as datetime — the bridge must convert it.
+        """
+        engine  = create_engine(f"sqlite:///{indexed_db}")
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        date_val = df["StudyDate"].iloc[0]
+        assert isinstance(date_val, str)
+        assert len(date_val) == 8
+        assert date_val.isdigit()
+ 
+    def test_empty_db_returns_empty_dataframe(self, tmp_path):
+        """Empty index should return empty DataFrame, not crash."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        session = sessionmaker(bind=engine)()
+        df = load_index_as_dataframe(session)
+        session.close()
+        assert df.empty
+
+class TestCreateAlbum:
+ 
+    def test_creates_album_for_matching_query(self, indexed_db):
+        """CT_small.dcm is a CT file — querying for CT should find it."""
+        album = create_album("My CT Album", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert album.name == "My CT Album"
+ 
+    def test_album_contains_matched_files(self, indexed_db):
+        """Album must actually contain the matched DICOM files."""
+        album = create_album("Files Test", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert len(album.files) >= 1
+ 
+    def test_album_stores_query_used(self, indexed_db):
+        """
+        The query string is stored on the album so you can see
+        how an album was built later — important for reproducibility.
+        """
+        query = "Modality == 'CT'"
+        album = create_album("Query Test", indexed_db, query=query)
+        assert album is not None
+        assert album.query_used == query
+ 
+    def test_album_has_unique_uuid(self, indexed_db):
+        """Every album must get a different UUID — no collisions."""
+        album1 = create_album("Album A", indexed_db, query="Modality == 'CT'")
+        album2 = create_album("Album B", indexed_db, query="Modality == 'CT'")
+        assert album1.album_id != album2.album_id
+ 
+    def test_album_has_created_at_timestamp(self, indexed_db):
+        """created_at must be set automatically on creation."""
+        album = create_album("Timestamped", indexed_db, query="Modality == 'CT'")
+        assert album is not None
+        assert isinstance(album.created_at, datetime)
+ 
+    def test_description_is_stored(self, indexed_db):
+        """Optional description should be saved correctly."""
+        album = create_album(
+            "Described", indexed_db,
+            query="Modality == 'CT'",
+            description="My test album"
+        )
+        assert album is not None
+        assert album.description == "My test album"
+ 
+    def test_no_match_returns_none(self, indexed_db):
+        """
+        If query matches nothing, return None instead of creating
+        an empty album — empty albums are useless.
+        """
+        album = create_album("Empty", indexed_db, query="Modality == 'MR'")
+        assert album is None
+ 
+    def test_empty_index_returns_none(self, tmp_path):
+        """If the index has no files at all, return None gracefully."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        album = create_album("Nothing", db_path, query="Modality == 'CT'")
+        assert album is None
+ 
+    def test_invalid_query_raises_value_error(self, indexed_db):
+        """
+        query_metadata raises ValueError for bad queries.
+        create_album must not swallow it — let it bubble up
+        so the caller knows the query was wrong.
+        """
+        with pytest.raises(ValueError):
+            create_album("Bad Query", indexed_db, query="InvalidField == 'CT'")
+ 
+    def test_date_range_query_works(self, indexed_db):
+        """
+        Test that the StudyDate YYYYMMDD conversion in load_index_as_dataframe
+        actually allows date range queries to work end-to-end.
+        """
+        album = create_album(
+            "Date Range",
+            indexed_db,
+            query="Modality == 'CT' and StudyDate > '20000101'"
+        )
+        assert album is not None
+ 
+    def test_two_albums_share_same_files(self, indexed_db):
+        """
+        The same DICOM file can belong to multiple albums.
+        This tests the many-to-many relationship works correctly.
+        """
+        album1 = create_album("First",  indexed_db, query="Modality == 'CT'")
+        album2 = create_album("Second", indexed_db, query="Modality == 'CT'")
+        assert album1 is not None
+        assert album2 is not None
+        # Both albums reference the same underlying file
+        assert album1.files[0].file_path == album2.files[0].file_path
+ 
+ 
+# ── Tests: list_albums and get_album ─────────────────────────────────────────
+ 
+class TestListAndGetAlbum:
+ 
+    def test_list_albums_returns_all(self, indexed_db):
+        """list_albums must return every album created."""
+        create_album("Album 1", indexed_db, query="Modality == 'CT'")
+        create_album("Album 2", indexed_db, query="Modality == 'CT'")
+        albums = list_albums(indexed_db)
+        assert len(albums) >= 2
+ 
+    def test_list_albums_empty_db(self, tmp_path):
+        """list_albums on empty DB should return empty list, not crash."""
+        db_path = str(tmp_path / "empty.db")
+        engine  = create_engine(f"sqlite:///{db_path}")
+        Base.metadata.create_all(engine)
+        assert list_albums(db_path) == []
+ 
+    def test_get_album_by_id(self, indexed_db):
+        """get_album must return the correct album by UUID."""
+        album   = create_album("Fetchable", indexed_db, query="Modality == 'CT'")
+        fetched = get_album(album.album_id, indexed_db)
+        assert fetched is not None
+        assert fetched.name == "Fetchable"
+ 
+    def test_get_album_wrong_id_returns_none(self, indexed_db):
+        """get_album with a non-existent ID must return None, not crash."""
+        result = get_album("00000000-0000-0000-0000-000000000000", indexed_db)
+        assert result is None
+ 

--- a/tests/test_dicomIndexer.py
+++ b/tests/test_dicomIndexer.py
@@ -1,0 +1,88 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "dicom-album-env", "Scripts"))
+
+from dicom_indexer import extract_metadata, parse_study_date, index_folder, DICOMIndex
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from pydicom.data import get_testdata_file
+
+@pytest.fixture
+def sample_dcm():
+    return get_testdata_file("CT_small.dcm")
+
+@pytest.fixture
+def tmp_db(tmp_path):
+    return str(tmp_path / "test_index.db")
+
+@pytest.fixture
+def tmp_dicom_dir(tmp_path, sample_dcm):
+    import shutil
+    shutil.copy(sample_dcm, tmp_path / "CT_small.dcm")
+    (tmp_path / "not_dicom.txt").write_text("this is not a dicom file")
+    return str(tmp_path)
+
+class TestParseStudyDate:
+    def test_valid_date_string(self):
+        result = parse_study_date("20200115")
+        assert result is not None
+        assert result.year == 2020
+    def test_none_input(self):
+        assert parse_study_date(None) is None
+    def test_empty_string(self):
+        assert parse_study_date("") is None
+    def test_invalid_format(self):
+        assert parse_study_date("not-a-date") is None
+
+class TestExtractMetadata:
+    def test_returns_dict_for_valid_dicom(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta is not None
+        assert isinstance(meta, dict)
+    def test_returns_none_for_non_dicom(self, tmp_path):
+        fake = tmp_path / "fake.dcm"
+        fake.write_text("this is not dicom content")
+        assert extract_metadata(str(fake)) is None
+    def test_contains_required_keys(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        for key in ["file_path", "patient_id", "study_uid", "modality", "study_date"]:
+            assert key in meta
+    def test_file_path_is_absolute(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert os.path.isabs(meta["file_path"])
+    def test_modality_is_ct(self, sample_dcm):
+        meta = extract_metadata(sample_dcm)
+        assert meta["modality"] == "CT"
+
+class TestIndexFolder:
+    def test_indexes_dicom_file(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count >= 1
+    def test_skips_non_dicom_files(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_no_duplicates_on_reindex(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        count = session.query(DICOMIndex).count()
+        session.close()
+        assert count == 1
+    def test_modality_stored_correctly(self, tmp_dicom_dir, tmp_db):
+        index_folder(tmp_dicom_dir, tmp_db)
+        engine = create_engine(f"sqlite:///{tmp_db}")
+        session = sessionmaker(bind=engine)()
+        record = session.query(DICOMIndex).first()
+        session.close()
+        assert record.modality == "CT"


### PR DESCRIPTION
This PR adds `album_api.py` — a Flask REST API that exposes the full DICOM album pipeline over HTTP.

Built on top of:
- `dicom_indexer.py` (PR #81) — scans folders, stores metadata in SQLite
- `album_manager.py` (PR #92) — queries index, creates named albums

## Endpoints

| Method | Endpoint | Description |
|--------|----------|-------------|
| POST | `/index` | Scan a folder and index all DICOM files into SQLite |
| POST | `/albums` | Create a named album using a query string |
| GET | `/albums` | List all albums |
| GET | `/albums/<album_id>` | Get a single album by UUID including file paths |

## Example usage

```bash
# Index a folder
curl -X POST http://localhost:5000/index \
  -H "Content-Type: application/json" \
  -d '{"folder": "/path/to/dicom/files"}'

# Create an album
curl -X POST http://localhost:5000/albums \
  -H "Content-Type: application/json" \
  -d '{"name": "CT 2023", "query": "Modality == '\''CT'\'' and StudyDate > '\''20230101'\''"}'

# List all albums
curl http://localhost:5000/albums

# Get one album
curl http://localhost:5000/albums/<album_id>
```

## Key design decisions
- All endpoints return consistent JSON with `status`, `error`, or `album` keys
- Invalid query strings return 400 with a clear error message
- No match returns 404 instead of creating empty albums
- `db_path` can be passed as a param to any endpoint — defaults to `DICOM_DB_PATH` env variable
- Also includes a fix to `album_manager.py` — added `joinedload` and `expunge_all` to resolve SQLAlchemy lazy loading issue when session closes before files are accessed

## Tests

18 tests across 4 classes — all passing:
- `TestIndexEndpoint` — 4 tests
- `TestCreateAlbumEndpoint` — 8 tests
- `TestListAlbumsEndpoint` — 3 tests
- `TestGetAlbumEndpoint` — 3 tests

Relates to issue #13 (shareable albums).