### PR TITLE
Add DICOM De-identification REST API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,4 @@
 DIOMEDE_SECRET_KEY=change-before-production
 
 # Other environment variables can be added here as needed, e.g. for database configuration, API keys, etc.
+DATABASE_URL=sqlite:///diomede.db

--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Ignore MacOS files
+.DS_Store
+
+# DICOM anonymization output
+storage/

--- a/Diomedex/__init__.py
+++ b/Diomedex/__init__.py
@@ -1,21 +1,31 @@
 import os
 import secrets
+from pathlib import Path
 
 from dotenv import load_dotenv
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
-from dotenv import load_dotenv
 
 load_dotenv()
 
+# Define db at module level before any submodule imports so that albums/models.py can resolve
+# `from .. import db` without a circular import.
 db = SQLAlchemy()
 
-from .albums.routes import albums_bp
-from .routing.routes import routing_bp
-from .routing import DICOMRouter
+def create_app(enable_routing=False, test_config=None):
+    # Blueprint imports are deferred here to avoid triggering the circular
+    # import chain at module load time.
+    from .albums.routes import albums_bp
+    from .routing.routes import routing_bp
+    from .routing import DICOMRouter
+    from .anonymization.routes import anonymization_bp
 
-def create_app(enable_routing=False):
     app = Flask(__name__)
+
+    if test_config is not None:
+        app.config.update(test_config)
+    else:
+        app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///diomede.db')
 
     secret_key = os.environ.get('DIOMEDE_SECRET_KEY')
     if not secret_key:
@@ -25,17 +35,26 @@ def create_app(enable_routing=False):
         secret_key = secrets.token_hex(32)
     app.config['SECRET_KEY'] = secret_key
 
-    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'sqlite:///diomede.db')
+    # Configure STORAGE_PATH for the DICOM sandbox.
+    if 'STORAGE_PATH' not in app.config:
+        app.config['STORAGE_PATH'] = os.environ.get(
+            'STORAGE_PATH',
+            str(Path(app.root_path).parent / "storage")
+        )
+
+    os.makedirs(app.config['STORAGE_PATH'], exist_ok=True)
+
     # Initialize db with app
     db.init_app(app)
-    
+
     # Register blueprints
     app.register_blueprint(albums_bp)
     app.register_blueprint(routing_bp)
-    
+    app.register_blueprint(anonymization_bp)
+
     # Initialize DICOM router if enabled
     if enable_routing:
         router = DICOMRouter()
         app.dicom_router = router
-    
+
     return app

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 from flask import Blueprint, request, jsonify, current_app
 from .core import DICOMAlbumCreator
 from .kheops import KheopsAdapter
-from .models import Album, DICOMFile, db
+from .models import Album, db
 
 albums_bp = Blueprint('albums', __name__)
 
@@ -18,10 +19,6 @@ def scan_directory():
         if not storage_path:
             current_app.logger.error("'STORAGE_PATH' is not configured.")
             return jsonify({'error': 'Server configuration error.'}), 500
-        
-        # Validate path to prevent path traversal attacks
-        from pathlib import Path
-        import os
         
         user_path = Path(data['path'])
         storage_base = Path(storage_path).resolve()

--- a/Diomedex/anonymization/__init__.py
+++ b/Diomedex/anonymization/__init__.py
@@ -1,0 +1,4 @@
+from .core import DICOMAnonymizer
+from .routes import anonymization_bp
+
+__all__ = ["DICOMAnonymizer", "anonymization_bp"]

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -1,0 +1,101 @@
+import logging
+import pickle
+from os import PathLike
+from pathlib import Path
+from typing import Dict, Union
+
+import pydicom
+from pydicom.uid import generate_uid
+from modules.dicom_anonymization.DicomAnonymizer2 import (
+    dcm_anonymize as _niffler_dcm_anonymize,
+    get_dcm_paths as _niffler_get_dcm_paths,
+)
+
+_REQUIRED_UID_TAGS = ("StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID")
+
+
+def _ensure_required_tags(file_path: str) -> None:
+    """Add any missing required UID tags to a DICOM file in-place.
+
+    Niffler's ``dcm_anonymize`` unconditionally accesses ``StudyInstanceUID``,
+    ``SeriesInstanceUID``, and ``SOPInstanceUID`` and will raise ``KeyError``
+    on files that lack them (e.g. minimal or legacy files).
+    This function silently patches missing tags with freshly generated UIDs so
+    the file can pass through Niffler without error.
+    """
+    # Check headers first without loading large pixel data into memory
+    ds = pydicom.dcmread(file_path, stop_before_pixels=True)
+    patched = False
+    for tag in _REQUIRED_UID_TAGS:
+        if tag not in ds:
+            patched = True
+            break
+
+    if patched:
+        # Re-read fully only if we actually need to save changes
+        ds = pydicom.dcmread(file_path)
+        for tag in _REQUIRED_UID_TAGS:
+            if tag not in ds:
+                setattr(ds, tag, generate_uid())
+        ds.save_as(file_path)
+
+
+LOG = logging.getLogger(__name__)
+
+
+class DICOMAnonymizer:
+    """Batch DICOM anonymizer backed by Niffler.
+
+    Delegates all PHI removal and ID generation to Niffler's ``dcm_anonymize``,
+    which generates a cryptographically random 25-character alphanumeric
+    PatientID per unique patient (via ``random.SystemRandom``) and remaps all
+    study/series/instance UIDs consistently across a batch.
+    """
+
+    def anonymize_directory(
+        self,
+        src_dir: Union[str, PathLike],
+        dest_dir: Union[str, PathLike],
+    ) -> Dict[str, int]:
+        """Recursively anonymize every DICOM file under *src_dir* using Niffler.
+
+        Output is organised as
+        ``dest/<PatientID>/<StudyUID>/<SeriesUID>/<SOPUID>.dcm``.
+
+        Args:
+            src_dir: Root directory containing source DICOM files.
+            dest_dir: Root directory for anonymized output.
+
+        Returns:
+            A dict with integer counts for ``processed``, ``skipped``, and ``failed`` files.
+
+        Raises:
+            ValueError: If *src_dir* and *dest_dir* resolve to the same path.
+        """
+        src = Path(src_dir)
+        dest = Path(dest_dir)
+
+        if src.resolve() == dest.resolve():
+            raise ValueError(
+                "Source and destination directories cannot be the same to prevent data corruption."
+            )
+
+        dcm_files = _niffler_get_dcm_paths(str(src))
+        if not dcm_files:
+            return {"processed": 0, "skipped": 0, "failed": 0}
+
+        for f in dcm_files:
+            _ensure_required_tags(f)
+
+        dest.mkdir(parents=True, exist_ok=True)
+        _niffler_dcm_anonymize(dcm_files, str(dest))
+
+        skipped_pkl = dest / "skipped.pkl"
+        failed = (
+            len(pickle.load(open(str(skipped_pkl), "rb")))
+            if skipped_pkl.exists()
+            else 0
+        )
+        processed = len(dcm_files) - failed
+
+        return {"processed": processed, "skipped": 0, "failed": failed}

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -25,18 +25,13 @@ def _ensure_required_tags(file_path: str) -> None:
     """
     # Check headers first without loading large pixel data into memory
     ds = pydicom.dcmread(file_path, stop_before_pixels=True)
-    patched = False
-    for tag in _REQUIRED_UID_TAGS:
-        if tag not in ds:
-            patched = True
-            break
+    missing_tags = [tag for tag in _REQUIRED_UID_TAGS if tag not in ds]
 
-    if patched:
+    if missing_tags:
         # Re-read fully only if we actually need to save changes
         ds = pydicom.dcmread(file_path)
-        for tag in _REQUIRED_UID_TAGS:
-            if tag not in ds:
-                setattr(ds, tag, generate_uid())
+        for tag in missing_tags:
+            setattr(ds, tag, generate_uid())
         ds.save_as(file_path)
 
 
@@ -91,11 +86,11 @@ class DICOMAnonymizer:
         _niffler_dcm_anonymize(dcm_files, str(dest))
 
         skipped_pkl = dest / "skipped.pkl"
-        failed = (
-            len(pickle.load(open(str(skipped_pkl), "rb")))
-            if skipped_pkl.exists()
-            else 0
-        )
+        if skipped_pkl.exists():
+            with open(str(skipped_pkl), "rb") as f:
+                failed = len(pickle.load(f))
+        else:
+            failed = 0
         processed = len(dcm_files) - failed
 
         return {"processed": processed, "skipped": 0, "failed": failed}

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -1,38 +1,50 @@
 import logging
 import pickle
+import tempfile
 from os import PathLike
 from pathlib import Path
-from typing import Dict, Union
+from typing import Dict, List, Union
 
 import pydicom
-from pydicom.uid import generate_uid
 from modules.dicom_anonymization.DicomAnonymizer2 import (
     dcm_anonymize as _niffler_dcm_anonymize,
+)
+from modules.dicom_anonymization.DicomAnonymizer2 import (
     get_dcm_paths as _niffler_get_dcm_paths,
 )
+from pydicom.uid import generate_uid
 
 _REQUIRED_UID_TAGS = ("StudyInstanceUID", "SeriesInstanceUID", "SOPInstanceUID")
 
 
-def _ensure_required_tags(file_path: str) -> None:
-    """Add any missing required UID tags to a DICOM file in-place.
+def _ensure_required_tags(file_path: str) -> str:
+    """Ensure a DICOM file has all UID tags required by Niffler.
 
     Niffler's ``dcm_anonymize`` unconditionally accesses ``StudyInstanceUID``,
     ``SeriesInstanceUID``, and ``SOPInstanceUID`` and will raise ``KeyError``
     on files that lack them (e.g. minimal or legacy files).
-    This function silently patches missing tags with freshly generated UIDs so
-    the file can pass through Niffler without error.
+
+    If all tags are already present the original *file_path* is returned
+    unchanged. If any are missing, a temporary copy is created with the tags
+    patched in and its path is returned instead — the source file is never
+    modified. The caller is responsible for deleting any returned temp file.
     """
     # Check headers first without loading large pixel data into memory
     ds = pydicom.dcmread(file_path, stop_before_pixels=True)
     missing_tags = [tag for tag in _REQUIRED_UID_TAGS if tag not in ds]
 
-    if missing_tags:
-        # Re-read fully only if we actually need to save changes
-        ds = pydicom.dcmread(file_path)
-        for tag in missing_tags:
-            setattr(ds, tag, generate_uid())
-        ds.save_as(file_path)
+    if not missing_tags:
+        return file_path
+
+    # Re-read fully to capture pixel data before saving the patched copy
+    ds = pydicom.dcmread(file_path)
+    for tag in missing_tags:
+        setattr(ds, tag, generate_uid())
+
+    tmp = tempfile.NamedTemporaryFile(suffix=".dcm", delete=False)
+    tmp.close()
+    ds.save_as(tmp.name)
+    return tmp.name
 
 
 LOG = logging.getLogger(__name__)
@@ -79,18 +91,38 @@ class DICOMAnonymizer:
         if not dcm_files:
             return {"processed": 0, "skipped": 0, "failed": 0}
 
+        patched_files: List[str] = []
+        temp_files: List[str] = []
+        pre_failed = 0
         for f in dcm_files:
-            _ensure_required_tags(f)
+            try:
+                patched = _ensure_required_tags(f)
+                patched_files.append(patched)
+                if patched != f:
+                    temp_files.append(patched)
+            except Exception as e:
+                LOG.warning("Skipping %s: could not patch required UID tags: %s", f, e)
+                pre_failed += 1
 
-        dest.mkdir(parents=True, exist_ok=True)
-        _niffler_dcm_anonymize(dcm_files, str(dest))
+        if not patched_files:
+            return {"processed": 0, "skipped": 0, "failed": pre_failed}
+
+        try:
+            dest.mkdir(parents=True, exist_ok=True)
+            _niffler_dcm_anonymize(patched_files, str(dest))
+        finally:
+            for tmp in temp_files:
+                Path(tmp).unlink(missing_ok=True)
 
         skipped_pkl = dest / "skipped.pkl"
         if skipped_pkl.exists():
+            # skipped.pkl is written by Niffler's DicomAnonymizer2, a trusted library
+            # maintained by the same organization KathiraveluLab. Loading its pickle
+            # output is an acceptable risk.
             with open(str(skipped_pkl), "rb") as f:
                 failed = len(pickle.load(f))
         else:
             failed = 0
-        processed = len(dcm_files) - failed
+        processed = len(patched_files) - failed
 
-        return {"processed": processed, "skipped": 0, "failed": failed}
+        return {"processed": processed, "skipped": 0, "failed": failed + pre_failed}

--- a/Diomedex/anonymization/routes.py
+++ b/Diomedex/anonymization/routes.py
@@ -1,0 +1,64 @@
+import logging
+from pathlib import Path
+
+from flask import Blueprint, jsonify, request, current_app
+
+from .core import DICOMAnonymizer
+
+LOG = logging.getLogger(__name__)
+
+anonymization_bp = Blueprint("anonymization", __name__, url_prefix="/anonymization")
+
+
+def _validate_path(raw: str) -> Path:
+    """Resolve a path string and require it to be absolute.
+
+    Raises:
+        ValueError: if the supplied path is not absolute.
+    """
+    p = Path(raw)
+    if not p.is_absolute():
+        raise ValueError(f"Path must be absolute, got: {raw!r}")
+    return p.resolve()
+
+
+def _check_within_storage(path: Path) -> None:
+    """Ensure *path* is contained within the configured STORAGE_PATH.
+
+    Raises:
+        ValueError: If *path* is not a descendant of STORAGE_PATH.
+    """
+    storage_base = Path(current_app.config["STORAGE_PATH"]).resolve()
+    try:
+        path.relative_to(storage_base)
+    except ValueError:
+        raise ValueError("Path must be within configured storage area")
+
+
+@anonymization_bp.route("/directory", methods=["POST"])
+def anonymize_directory():
+    """Recursively anonymize all DICOM files under a directory.
+
+    Request body (JSON):
+        src (str): Absolute path to the root source directory.
+        dest (str): Absolute path to the root output directory.
+    Returns:
+        200: ``{"status": "success", "stats": {"processed": N, "skipped": N, "failed": N}}``
+        400: ``{"error": "..."}`` when ``src`` or ``dest`` is missing.
+    """
+    data = request.get_json()
+    if not data or "src" not in data or "dest" not in data:
+        return jsonify({"error": "'src' and 'dest' parameters are required"}), 400
+
+    try:
+        src_dir = _validate_path(data["src"])
+        dest_dir = _validate_path(data["dest"])
+        _check_within_storage(dest_dir)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": f"Internal processing error: {str(e)}"}), 500
+
+    anonymizer = DICOMAnonymizer()
+    stats = anonymizer.anonymize_directory(src_dir, dest_dir)
+    return jsonify({"status": "success", "stats": stats}), 200

--- a/Diomedex/anonymization/routes.py
+++ b/Diomedex/anonymization/routes.py
@@ -57,7 +57,8 @@ def anonymize_directory():
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
     except Exception as e:
-        return jsonify({"error": f"Internal processing error: {str(e)}"}), 500
+        LOG.error("Unexpected error during path validation: %s", e, exc_info=True)
+        return jsonify({"error": "An internal processing error occurred."}), 500
 
     anonymizer = DICOMAnonymizer()
     stats = anonymizer.anonymize_directory(src_dir, dest_dir)

--- a/Diomedex/anonymization/routes.py
+++ b/Diomedex/anonymization/routes.py
@@ -52,6 +52,12 @@ def anonymize_directory():
 
     try:
         src_dir = _validate_path(data["src"])
+        # src is intentionally not restricted to STORAGE_PATH. It is treated as
+        # read-only by this API and may legitimately reside outside the storage
+        # sandbox (e.g. a scanner's network mount or an incoming data drop). Only
+        # DICOM files discovered by Niffler are ever read, which significantly
+        # limits the accessible scope. The sandbox constraint applies only to dest,
+        # where anonymized output is written.
         dest_dir = _validate_path(data["dest"])
         _check_within_storage(dest_dir)
     except ValueError as e:

--- a/Diomedex/models.py
+++ b/Diomedex/models.py
@@ -1,0 +1,5 @@
+# Re-export album models at the Diomedex package level so that
+# `from Diomedex.models import ...` resolves correctly.
+from .albums.models import db, DICOMFile, Album
+
+__all__ = ["db", "DICOMFile", "Album"]

--- a/Diomedex/utils/dicom_helpers.py
+++ b/Diomedex/utils/dicom_helpers.py
@@ -19,7 +19,10 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
     """
     try:
         dataset = pydicom.dcmread(file_path)
-    except (pydicom.errors.InvalidDicomError, EOFError, ValueError, OSError) as ex:
+    except (pydicom.errors.InvalidDicomError,
+            EOFError,
+            ValueError,
+            OSError) as ex:
         LOG.warning("Skipping invalid or corrupted DICOM file: %s (%s)", file_path, ex)
         return None
 
@@ -28,17 +31,17 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
 
 def extract_basic_metadata(file_path: Union[str, PathLike]):
     dataset = safe_load_dicom_file(file_path)
-    if dataset is None:
-        return {
-            "PatientID": None,
-            "StudyDate": None,
-            "Modality": None,
-            "SeriesInstanceUID": None,
-        }
+if dataset is None:
+    return {
+        'PatientID': None,
+        'StudyDate': None,
+        'Modality': None,
+        'SeriesInstanceUID': None,
+    }
 
     return {
-        "PatientID": dataset.get("PatientID", None),
-        "StudyDate": dataset.get("StudyDate", None),
-        "Modality": dataset.get("Modality", None),
-        "SeriesInstanceUID": dataset.get("SeriesInstanceUID", None),
+        'PatientID': dataset.get('PatientID', None),
+        'StudyDate': dataset.get('StudyDate', None),
+        'Modality': dataset.get('Modality', None),
+        'SeriesInstanceUID': dataset.get('SeriesInstanceUID', None),
     }

--- a/Diomedex/utils/dicom_helpers.py
+++ b/Diomedex/utils/dicom_helpers.py
@@ -19,10 +19,7 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
     """
     try:
         dataset = pydicom.dcmread(file_path)
-    except (pydicom.errors.InvalidDicomError,
-            EOFError,
-            ValueError,
-            OSError) as ex:
+    except (pydicom.errors.InvalidDicomError, EOFError, ValueError, OSError) as ex:
         LOG.warning("Skipping invalid or corrupted DICOM file: %s (%s)", file_path, ex)
         return None
 
@@ -31,17 +28,17 @@ def safe_load_dicom_file(file_path: Union[str, PathLike]):
 
 def extract_basic_metadata(file_path: Union[str, PathLike]):
     dataset = safe_load_dicom_file(file_path)
-if dataset is None:
-    return {
-        'PatientID': None,
-        'StudyDate': None,
-        'Modality': None,
-        'SeriesInstanceUID': None,
-    }
+    if dataset is None:
+        return {
+            "PatientID": None,
+            "StudyDate": None,
+            "Modality": None,
+            "SeriesInstanceUID": None,
+        }
 
     return {
-        'PatientID': dataset.get('PatientID', None),
-        'StudyDate': dataset.get('StudyDate', None),
-        'Modality': dataset.get('Modality', None),
-        'SeriesInstanceUID': dataset.get('SeriesInstanceUID', None),
+        "PatientID": dataset.get("PatientID", None),
+        "StudyDate": dataset.get("StudyDate", None),
+        "Modality": dataset.get("Modality", None),
+        "SeriesInstanceUID": dataset.get("SeriesInstanceUID", None),
     }

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pytest>=6.2.0
 flask-cors>=3.0.10
 pynetdicom>=3.0.4
 pandas>=1.3.0
+
+# Niffler provides the core DICOM anonymization logic consumed by this project.
+Niffler @ git+https://github.com/KathiraveluLab/Niffler.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,5 @@ pynetdicom>=3.0.4
 pandas>=1.3.0
 
 # Niffler provides the core DICOM anonymization logic consumed by this project.
+# TODO: pin to a stable release tag once Niffler publishes one (currently under active development)
 Niffler @ git+https://github.com/KathiraveluLab/Niffler.git

--- a/tests/test_anonymization.py
+++ b/tests/test_anonymization.py
@@ -1,0 +1,178 @@
+"""
+Tests for the DICOM Anonymization Module.
+
+Covers:
+  - Directory batch anonymization via Niffler
+  - Flask REST API endpoint (/anonymization/directory)
+"""
+
+import json
+import pytest
+from pydicom.dataset import FileDataset
+from pydicom.uid import ExplicitVRLittleEndian, generate_uid
+import pydicom
+from Diomedex import create_app
+from Diomedex.anonymization.core import DICOMAnonymizer
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CT_CLASS_UID = "1.2.840.10008.5.1.4.1.1.2"
+
+
+def _make_dicom_file(tmp_path, filename: str = "test.dcm", **tags) -> tuple:
+    """Write a minimal valid DICOM Part-10 file and return (path, dataset)."""
+    sop_uid = tags.pop("SOPInstanceUID", generate_uid())
+
+    file_meta = pydicom.Dataset()
+    file_meta.MediaStorageSOPClassUID = CT_CLASS_UID
+    file_meta.MediaStorageSOPInstanceUID = sop_uid
+    file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
+
+    ds = FileDataset(
+        str(tmp_path / filename),
+        {},
+        file_meta=file_meta,
+        preamble=b"\x00" * 128,
+    )
+    ds.SOPClassUID = CT_CLASS_UID
+    ds.SOPInstanceUID = sop_uid
+    ds.StudyInstanceUID = tags.pop("StudyInstanceUID", generate_uid())
+    ds.SeriesInstanceUID = tags.pop("SeriesInstanceUID", generate_uid())
+    ds.PatientName = tags.pop("PatientName", "Doe^John")
+    ds.PatientID = tags.pop("PatientID", "P001")
+    ds.PatientBirthDate = tags.pop("PatientBirthDate", "19800101")
+    ds.PatientSex = tags.pop("PatientSex", "M")
+    ds.InstitutionName = tags.pop("InstitutionName", "Test Hospital")
+    ds.ReferringPhysicianName = tags.pop("ReferringPhysicianName", "Smith^Jane")
+    ds.AccessionNumber = tags.pop("AccessionNumber", "ACC001")
+    ds.Modality = tags.pop("Modality", "CT")
+    for key, val in tags.items():
+        setattr(ds, key, val)
+
+    path = tmp_path / filename
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ds.save_as(str(path))
+    return path, ds
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app(tmp_path_factory):
+    """Create a Flask app for testing with a configured STORAGE_PATH."""
+    storage_root = tmp_path_factory.getbasetemp()
+    return create_app(
+        test_config={
+            "TESTING": True,
+            "SQLALCHEMY_DATABASE_URI": "sqlite:///:memory:",
+            "STORAGE_PATH": str(storage_root),
+        }
+    )
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# 1. Directory batch anonymization
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizeDirectory:
+    def test_all_dicom_files_processed(self, tmp_path):
+        src = tmp_path / "src"
+        dest = tmp_path / "dest"
+        src.mkdir()
+        for i in range(3):
+            _make_dicom_file(src, f"f{i}.dcm")
+
+        stats = DICOMAnonymizer().anonymize_directory(src, dest)
+        assert stats["processed"] == 3
+        assert stats["failed"] == 0
+
+    def test_non_dicom_files_are_ignored(self, tmp_path):
+        src = tmp_path / "src"
+        dest = tmp_path / "dest"
+        src.mkdir()
+        _make_dicom_file(src, "real.dcm")
+        (src / "note.txt").write_text("not dicom")
+
+        # Niffler's get_dcm_paths only finds *.dcm files so the txt is never seen
+        stats = DICOMAnonymizer().anonymize_directory(src, dest)
+        assert stats["processed"] == 1
+        assert stats["failed"] == 0
+
+    def test_empty_directory_returns_zero_stats(self, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        stats = DICOMAnonymizer().anonymize_directory(src, tmp_path / "dest")
+        assert stats == {"processed": 0, "skipped": 0, "failed": 0}
+
+    def test_same_src_and_dest_raises(self, tmp_path):
+        with pytest.raises(ValueError):
+            DICOMAnonymizer().anonymize_directory(tmp_path, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 2. Flask API endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAnonymizationAPI:
+    def test_directory_endpoint_success(self, client, tmp_path):
+        src = tmp_path / "src"
+        dest = tmp_path / "dest"
+        src.mkdir()
+        _make_dicom_file(src, "f1.dcm")
+        _make_dicom_file(src, "f2.dcm")
+
+        resp = client.post(
+            "/anonymization/directory",
+            data=json.dumps({"src": str(src), "dest": str(dest)}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "success"
+        assert data["stats"]["processed"] == 2
+        assert data["stats"]["failed"] == 0
+
+    def test_directory_endpoint_missing_params(self, client, tmp_path):
+        resp = client.post(
+            "/anonymization/directory",
+            data=json.dumps({"src": str(tmp_path)}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+
+    def test_directory_endpoint_no_body_returns_400(self, client):
+        resp = client.post("/anonymization/directory", content_type="application/json")
+        assert resp.status_code == 400
+
+    def test_endpoint_rejects_relative_path(self, client, tmp_path):
+        resp = client.post(
+            "/anonymization/directory",
+            data=json.dumps({"src": "relative/path", "dest": str(tmp_path / "out")}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "Path must be absolute" in resp.get_json()["error"]
+
+    def test_endpoint_rejects_dest_outside_storage(self, client, tmp_path):
+        src = tmp_path / "src"
+        src.mkdir()
+        resp = client.post(
+            "/anonymization/directory",
+            data=json.dumps({"src": str(src), "dest": "/tmp/escaped_anon"}),
+            content_type="application/json",
+        )
+        assert resp.status_code == 400
+        assert "within configured storage area" in resp.get_json()["error"]

--- a/tests/test_anonymization.py
+++ b/tests/test_anonymization.py
@@ -7,13 +7,14 @@ Covers:
 """
 
 import json
+
+import pydicom
 import pytest
 from pydicom.dataset import FileDataset
 from pydicom.uid import ExplicitVRLittleEndian, generate_uid
-import pydicom
+
 from Diomedex import create_app
 from Diomedex.anonymization.core import DICOMAnonymizer
-
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
Supersedes and extends #80.

Adds POST `/anonymization/directory` - a REST endpoint that exposes Niffler's DICOM anonymization engine via the Diomede API.

DICOM files from clinical scanners contain protected health information (PHI). This endpoint allows callers to de-identify a directory of DICOM files programmatically without requiring direct access to Niffler or manual tooling, making it straightforward to integrate de-identification into data pipelines and workflows built on top of Diomede.

Also this endpoint automatically patches  legacy and minimal DICOM files missing required UID fields (`StudyInstanceUID`, `SeriesInstanceUID`, `SOPInstanceUID`) before processing so it can handle real-world files from older or non-compliant scanners without throwing errors.

Security features:
  - dest is confined to the server's `STORAGE_PATH` - requests targeting paths outside the sandbox are rejected with the 400 error code
  - No patient data is logged or returned in API responses