### PR TITLE
fix: remove deprecated pydicom attributes from test_albums

### DIFF
--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -30,8 +30,6 @@ def test_scan_directory(tmp_path, app):
     ds.PatientID = "12345"
     ds.StudyInstanceUID = "1.2.3.4"
     ds.Modality = "CT"
-    ds.is_little_endian = True
-    ds.is_implicit_VR = False
     ds.save_as(str(dcm_file))
     with app.app_context():
         creator = DICOMAlbumCreator(str(tmp_path))

--- a/tests/test_albums.py
+++ b/tests/test_albums.py
@@ -30,7 +30,7 @@ def test_scan_directory(tmp_path, app):
     ds.PatientID = "12345"
     ds.StudyInstanceUID = "1.2.3.4"
     ds.Modality = "CT"
-    ds.save_as(str(dcm_file))
+    ds.save_as(dcm_file)
     with app.app_context():
         creator = DICOMAlbumCreator(str(tmp_path))
         files = creator.scan_directory(str(tmp_path))


### PR DESCRIPTION
Removes two deprecated pydicom attributes from test_scan_directory in tests/test_albums.py.

ds.is_little_endian and ds.is_implicit_VR are scheduled for removal in pydicom v4.0. Both were redundant since the Transfer Syntax UID (ExplicitVRLittleEndian) was already set in the file meta, which implies little endian and explicit VR.
Both tests still pass, deprecation warnings are gone.