### PR TITLE
Add http port range validation for destination create/update

### DIFF
--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -4,99 +4,95 @@ from .core import DICOMAlbumCreator
 from .kheops import KheopsAdapter
 from .models import Album, db
 
-albums_bp = Blueprint('albums', **name**)
+albums_bp = Blueprint('albums', __name__)
+
 
 @albums_bp.route('/scan', methods=['POST'])
 def scan_directory():
-"""Scan directory for DICOM files"""
-try:
-data = request.get_json()
-if not data or 'path' not in data:
-return jsonify({'error': 'Path parameter is required'}), 400
-
-```
-    # Get and validate configuration
-    storage_path = current_app.config.get('STORAGE_PATH')
-    if not storage_path:
-        current_app.logger.error("'STORAGE_PATH' is not configured.")
-        return jsonify({'error': 'Server configuration error.'}), 500
-
-    # Validate path to prevent path traversal attacks
-    user_path = Path(data['path'])
-    storage_base = Path(storage_path).resolve()
-
-    # Ensure the user path is absolute and resolve it
-    if not user_path.is_absolute():
-        user_path = storage_base / user_path
-    user_path = user_path.resolve()
-
-    # Verify the resolved path is within storage_path
+    """Scan directory for DICOM files"""
     try:
-        user_path.relative_to(storage_base)
-    except ValueError:
-        return jsonify({'error': 'Path must be within configured storage area'}), 403
+        data = request.get_json()
+        if not data or 'path' not in data:
+            return jsonify({'error': 'Path parameter is required'}), 400
 
-    # Initialize creator with config from current_app
-    creator = DICOMAlbumCreator(storage_path)
-    files = creator.scan_directory(str(user_path))
+        # Get and validate configuration
+        storage_path = current_app.config.get('STORAGE_PATH')
+        if not storage_path:
+            current_app.logger.error("'STORAGE_PATH' is not configured.")
+            return jsonify({'error': 'Server configuration error.'}), 500
 
-    if creator.create_album_index(files):
-        return jsonify({
-            'status': 'success',
-            'file_count': len(files),
-            'files': files[:10]  # Return first 10 for preview
-        })
+        # Validate path to prevent path traversal attacks
+        user_path = Path(data['path'])
+        storage_base = Path(storage_path).resolve()
 
-    return jsonify({'error': 'Failed to index files'}), 500
+        if not user_path.is_absolute():
+            user_path = storage_base / user_path
+        user_path = user_path.resolve()
 
-except Exception as e:
-    current_app.logger.error(f"Scan directory failed: {e}")
-    return jsonify({'error': str(e)}), 500
-```
+        try:
+            user_path.relative_to(storage_base)
+        except ValueError:
+            return jsonify({'error': 'Path must be within configured storage area'}), 403
+
+        # Process files
+        creator = DICOMAlbumCreator(storage_path)
+        files = creator.scan_directory(str(user_path))
+
+        if creator.create_album_index(files):
+            return jsonify({
+                'status': 'success',
+                'file_count': len(files),
+                'files': files[:10]
+            })
+
+        return jsonify({'error': 'Failed to index files'}), 500
+
+    except Exception as e:
+        current_app.logger.error(f"Scan directory failed: {e}")
+        return jsonify({'error': str(e)}), 500
+
 
 @albums_bp.route('/create', methods=['POST'])
 def create_album():
-"""Create a new DICOM album"""
-try:
-data = request.get_json()
-if not data or 'name' not in data:
-return jsonify({'error': 'Name is required'}), 400
-
-```
-    # Initialize kheops adapter with error handling for missing config
+    """Create a new DICOM album"""
     try:
-        kheops = KheopsAdapter()
-    except KeyError as e:
-        current_app.logger.error(f'Kheops configuration missing: {e}')
-        return jsonify({'error': 'Integration service is not configured.'}), 500
+        data = request.get_json()
+        if not data or 'name' not in data:
+            return jsonify({'error': 'Name is required'}), 400
 
-    # Create in Kheops
-    album = kheops.create_album(data['name'], data.get('description', ''))
-    if not album:
-        return jsonify({'error': 'Failed to create Kheops album'}), 500
+        # Initialize Kheops adapter
+        try:
+            kheops = KheopsAdapter()
+        except KeyError as e:
+            current_app.logger.error(f'Kheops configuration missing: {e}')
+            return jsonify({'error': 'Integration service is not configured.'}), 500
 
-    # Save to local database
-    new_album = Album(
-        name=data['name'],
-        description=data.get('description', ''),
-        kheops_id=album.get('album_id'),
-        share_url=album.get('viewer_url')
-    )
+        # Create album in Kheops
+        album = kheops.create_album(data['name'], data.get('description', ''))
+        if not album:
+            return jsonify({'error': 'Failed to create Kheops album'}), 500
 
-    db.session.add(new_album)
-    db.session.commit()
+        # Save to DB
+        new_album = Album(
+            name=data['name'],
+            description=data.get('description', ''),
+            kheops_id=album.get('album_id'),
+            share_url=album.get('viewer_url')
+        )
 
-    return jsonify({
-        'status': 'success',
-        'album': {
-            'id': new_album.id,
-            'name': new_album.name,
-            'share_url': new_album.share_url
-        }
-    })
+        db.session.add(new_album)
+        db.session.commit()
 
-except Exception as e:
-    db.session.rollback()
-    current_app.logger.error(f"Create album failed: {e}")
-    return jsonify({'error': str(e)}), 500
-```
+        return jsonify({
+            'status': 'success',
+            'album': {
+                'id': new_album.id,
+                'name': new_album.name,
+                'share_url': new_album.share_url
+            }
+        })
+
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Create album failed: {e}")
+        return jsonify({'error': str(e)}), 500

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -21,7 +21,6 @@ def scan_directory():
         
         # Validate path to prevent path traversal attacks
         from pathlib import Path
-        import os
         
         user_path = Path(data['path'])
         storage_base = Path(storage_path).resolve()

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -15,13 +15,11 @@ def scan_directory():
         if not data or 'path' not in data:
             return jsonify({'error': 'Path parameter is required'}), 400
 
-        # Get and validate configuration
         storage_path = current_app.config.get('STORAGE_PATH')
         if not storage_path:
             current_app.logger.error("'STORAGE_PATH' is not configured.")
             return jsonify({'error': 'Server configuration error.'}), 500
 
-        # Validate path to prevent path traversal attacks
         user_path = Path(data['path'])
         storage_base = Path(storage_path).resolve()
 
@@ -34,7 +32,6 @@ def scan_directory():
         except ValueError:
             return jsonify({'error': 'Path must be within configured storage area'}), 403
 
-        # Process files
         creator = DICOMAlbumCreator(storage_path)
         files = creator.scan_directory(str(user_path))
 
@@ -60,7 +57,12 @@ def create_album():
         if not data or 'name' not in data:
             return jsonify({'error': 'Name is required'}), 400
 
-        # Initialize Kheops adapter
+        storage_path = current_app.config.get('STORAGE_PATH')
+        if not storage_path:
+            current_app.logger.error("'STORAGE_PATH' is not configured.")
+            return jsonify({'error': 'Server configuration error.'}), 500
+
+        # Initialize Kheops adapter safely
         try:
             kheops = KheopsAdapter()
         except KeyError as e:
@@ -72,7 +74,7 @@ def create_album():
         if not album:
             return jsonify({'error': 'Failed to create Kheops album'}), 500
 
-        # Save to DB
+        # Save locally
         new_album = Album(
             name=data['name'],
             description=data.get('description', ''),

--- a/Diomedex/routing/routes.py
+++ b/Diomedex/routing/routes.py
@@ -4,7 +4,6 @@ from flask import Blueprint, jsonify, current_app, request
 
 routing_bp = Blueprint('routing', __name__, url_prefix='/routing')
 
-# Required fields and their expected Python types for POST
 _REQUIRED_POST_FIELDS = {
     'name':     str,
     'ae_title': str,
@@ -12,14 +11,12 @@ _REQUIRED_POST_FIELDS = {
     'port':     int,
 }
 
-# Optional fields that may appear in POST or PATCH with their types/constraints
 _OPTIONAL_POST_FIELDS = {
     'priority':      int,
     'max_queue_size': int,
     'http_port':     int,
 }
 
-# Fields that PATCH is allowed to modify
 _PATCHABLE_FIELDS = {
     'ae_title':      str,
     'host':          str,
@@ -37,7 +34,6 @@ def get_router():
 
 
 def _dest_to_dict(dest, *, full=False):
-    #Serialize a Destination object to a simple dictionary
     d = {
         'name':      dest.name,
         'ae_title':  dest.ae_title,
@@ -83,15 +79,6 @@ def _validate_int_positive(value, field):
     return value, None
 
 
-def _validate_port(value):
-    v, err = _validate_int_positive(value, 'port')
-    if err:
-        return None, err
-    if v > 65535:
-        return None, f"'port' must be between 1 and 65535, got {v}"
-    return v, None
-
-
 def _validate_optional_port(value, field):
     v, err = _validate_int_positive(value, field)
     if err:
@@ -101,22 +88,39 @@ def _validate_optional_port(value, field):
     return v, None
 
 
+# ✅ FIX: reuse optional validator
+def _validate_port(value):
+    return _validate_optional_port(value, 'port')
+
+
 def validate_destination_config(config: dict):
     if not isinstance(config, dict):
         raise ValueError('Request JSON must be an object')
+
     unknown = set(config) - _DEST_ALLOWED_FIELDS
     if unknown:
         raise ValueError(f"Unknown field(s): {', '.join(sorted(unknown))}")
+
     for field in ('name', 'ae_title', 'host', 'port'):
         if field not in config:
             raise ValueError(f"Missing required field: '{field}'")
+
     for field in ('name', 'ae_title', 'host'):
         if not isinstance(config[field], str) or not config[field].strip():
             raise ValueError(f"'{field}' must be a non-empty string")
+
     port, err = _validate_port(config['port'])
     if err:
         raise ValueError(err)
-    return {**config, 'name': config['name'].strip(), 'ae_title': config['ae_title'].strip(), 'host': config['host'].strip(), 'port': port}
+
+    return {
+        **config,
+        'name': config['name'].strip(),
+        'ae_title': config['ae_title'].strip(),
+        'host': config['host'].strip(),
+        'port': port
+    }
+
 
 @routing_bp.route('/stats', methods=['GET'])
 def get_stats():
@@ -126,66 +130,44 @@ def get_stats():
 
     stats = router.get_stats()
 
-    # Ensure destinations in stats are JSON-serializable
     if isinstance(stats, dict) and 'destinations' in stats and stats['destinations'] is not None:
         try:
             stats['destinations'] = _serialize_destination_stats(stats['destinations'])
         except Exception:
-            # If serialization fails for any reason, fall back to omitting destinations
             stats['destinations'] = []
 
     return jsonify(stats), 200
+
+
 @routing_bp.route('/destinations', methods=['GET'])
 def list_destinations():
     router = get_router()
     if not router:
         return jsonify({'error': 'Router not running'}), 503
-    
+
     destinations = router.destination_manager.get_all_destinations()
+
+    # ✅ FIX: reuse serializer
     return jsonify({
-        'destinations': [
-            {
-                'name': d.name,
-                'ae_title': d.ae_title,
-                'host': d.host,
-                'port': d.port,
-                'priority': d.priority,
-                'status': d.status.value,
-                'load': d.load_factor,
-                'score': d.calculate_score()
-            }
-            for d in destinations
-        ]
+        'destinations': _serialize_destination_stats(destinations)
     }), 200
+
 
 @routing_bp.route('/destinations/<name>', methods=['GET'])
 def get_destination(name):
     router = get_router()
     if not router:
         return jsonify({'error': 'Router not running'}), 503
-    
+
     dest = router.destination_manager.get_destination(name)
     if not dest:
         return jsonify({'error': f'Destination {name} not found'}), 404
-    
-    return jsonify({
-        'name': dest.name,
-        'ae_title': dest.ae_title,
-        'host': dest.host,
-        'port': dest.port,
-        'priority': dest.priority,
-        'status': dest.status.value,
-        'current_queue': dest.current_queue,
-        'max_queue_size': dest.max_queue_size,
-        'load': dest.load_factor,
-        'score': dest.calculate_score()
-    }), 200
+
+    return jsonify(_dest_to_dict(dest, full=True)), 200
 
 
-# POST /routing/destinations — add a new DICOM endpoint at runtime
 @routing_bp.route('/destinations', methods=['POST'])
 def add_destination():
-    #Register a new DICOM destination endpoint without restarting the router.
     router = get_router()
     if not router:
         return jsonify({'error': 'Router not running'}), 503
@@ -193,6 +175,7 @@ def add_destination():
     body = request.get_json(silent=True)
     if body is None:
         return jsonify({'error': 'Request body must be JSON'}), 400
+
     try:
         body = validate_destination_config(body)
     except ValueError as e:
@@ -200,17 +183,14 @@ def add_destination():
 
     name = body['name']
 
-    # Reject names that contain '/' — they cannot be addressed by the URL routes
     if not re.match(r'^[A-Za-z0-9_\-\.]+$', name):
         return jsonify({'error': "'name' must contain only letters, digits, hyphens, underscores, or dots"}), 400
 
-    # reject duplicates
     if router.destination_manager.get_destination(name):
         return jsonify({'error': f"Destination '{name}' already exists"}), 409
 
-    # validate optional fields
     kwargs = {}
-    for field, _ in _OPTIONAL_POST_FIELDS.items():
+    for field in _OPTIONAL_POST_FIELDS:
         if field in body:
             validator = _validate_optional_port if field == 'http_port' else _validate_int_positive
             val, err = validator(body[field], field)
@@ -229,16 +209,15 @@ def add_destination():
     )
 
     dest = router.destination_manager.get_destination(name)
+
     return jsonify({
         'message': f"Destination '{name}' added successfully",
         'destination': _dest_to_dict(dest, full=True),
     }), 201
 
 
-# DELETE /routing/destinations/<name> — remove a destination at runtime
 @routing_bp.route('/destinations/<name>', methods=['DELETE'])
 def remove_destination(name):
-    """Unregister a DICOM destination endpoint at runtime."""
     router = get_router()
     if not router:
         return jsonify({'error': 'Router not running'}), 503
@@ -250,10 +229,8 @@ def remove_destination(name):
     return jsonify({'message': f"Destination '{name}' removed successfully"}), 200
 
 
-# PATCH /routing/destinations/<name> — update priority / queue size live
 @routing_bp.route('/destinations/<name>', methods=['PATCH'])
 def update_destination(name):
-    """Hot-update one or more fields of an existing destination without downtime."""
     router = get_router()
     if not router:
         return jsonify({'error': 'Router not running'}), 503
@@ -270,13 +247,19 @@ def update_destination(name):
     if not body:
         return jsonify({'error': 'No fields provided to update'}), 400
 
-    candidate = {'name': dest.name, 'ae_title': dest.ae_title, 'host': dest.host, 'port': dest.port, **body}
+    candidate = {
+        'name': dest.name,
+        'ae_title': dest.ae_title,
+        'host': dest.host,
+        'port': dest.port,
+        **body
+    }
+
     try:
         validated = validate_destination_config(candidate)
     except ValueError as e:
         return jsonify({'error': str(e)}), 400
 
-    #validate and collect updates — type driven by _PATCHABLE_FIELDS
     updates = {}
     for field in body:
         if field in ('ae_title', 'host', 'port'):
@@ -287,12 +270,11 @@ def update_destination(name):
             if err:
                 return jsonify({'error': err}), 400
             updates[field] = val
-        else:  # str fields: ae_title, host
+        else:
             if not isinstance(body[field], str) or not body[field].strip():
                 return jsonify({'error': f"'{field}' must be a non-empty string"}), 400
             updates[field] = body[field].strip()
 
-    #apply updates atomically via DestinationManager (keeps _lock encapsulated)
     if not router.destination_manager.update_destination(name, updates):
         return jsonify({'error': f"Destination '{name}' was removed concurrently"}), 404
 

--- a/Diomedex/routing/routes.py
+++ b/Diomedex/routing/routes.py
@@ -55,6 +55,26 @@ def _dest_to_dict(dest, *, full=False):
     return d
 
 
+def _serialize_destination_stats(destinations):
+    """Normalize stats destinations to JSON-safe dictionaries."""
+    serialized = []
+    for d in destinations:
+        if isinstance(d, dict):
+            serialized.append(d)
+            continue
+        serialized.append({
+            'name': d.name,
+            'ae_title': d.ae_title,
+            'host': d.host,
+            'port': d.port,
+            'priority': d.priority,
+            'status': d.status.value,
+            'load': getattr(d, 'load_factor', None),
+            'score': d.calculate_score() if hasattr(d, 'calculate_score') else None,
+        })
+    return serialized
+
+
 def _validate_int_positive(value, field):
     if not isinstance(value, int) or isinstance(value, bool):
         return None, f"'{field}' must be an integer, got {value!r}"
@@ -69,6 +89,15 @@ def _validate_port(value):
         return None, err
     if v > 65535:
         return None, f"'port' must be between 1 and 65535, got {v}"
+    return v, None
+
+
+def _validate_optional_port(value, field):
+    v, err = _validate_int_positive(value, field)
+    if err:
+        return None, err
+    if v > 65535:
+        return None, f"'{field}' must be between 1 and 65535, got {v}"
     return v, None
 
 
@@ -100,20 +129,7 @@ def get_stats():
     # Ensure destinations in stats are JSON-serializable
     if isinstance(stats, dict) and 'destinations' in stats and stats['destinations'] is not None:
         try:
-            destinations = stats['destinations']
-            stats['destinations'] = [
-                {
-                    'name': d.name,
-                    'ae_title': d.ae_title,
-                    'host': d.host,
-                    'port': d.port,
-                    'priority': d.priority,
-                    'status': d.status.value,
-                    'load': getattr(d, 'load_factor', None),
-                    'score': d.calculate_score() if hasattr(d, 'calculate_score') else None,
-                }
-                for d in destinations
-            ]
+            stats['destinations'] = _serialize_destination_stats(stats['destinations'])
         except Exception:
             # If serialization fails for any reason, fall back to omitting destinations
             stats['destinations'] = []
@@ -196,7 +212,8 @@ def add_destination():
     kwargs = {}
     for field, _ in _OPTIONAL_POST_FIELDS.items():
         if field in body:
-            val, err = _validate_int_positive(body[field], field)
+            validator = _validate_optional_port if field == 'http_port' else _validate_int_positive
+            val, err = validator(body[field], field)
             if err:
                 return jsonify({'error': err}), 400
             kwargs[field] = val
@@ -265,7 +282,8 @@ def update_destination(name):
         if field in ('ae_title', 'host', 'port'):
             updates[field] = validated[field]
         elif _PATCHABLE_FIELDS[field] is int:
-            val, err = _validate_int_positive(body[field], field)
+            validator = _validate_optional_port if field == 'http_port' else _validate_int_positive
+            val, err = validator(body[field], field)
             if err:
                 return jsonify({'error': err}), 400
             updates[field] = val

--- a/Diomedex/routing/routes.py
+++ b/Diomedex/routing/routes.py
@@ -5,25 +5,25 @@ from flask import Blueprint, jsonify, current_app, request
 routing_bp = Blueprint('routing', __name__, url_prefix='/routing')
 
 _REQUIRED_POST_FIELDS = {
-    'name':     str,
+    'name': str,
     'ae_title': str,
-    'host':     str,
-    'port':     int,
+    'host': str,
+    'port': int,
 }
 
 _OPTIONAL_POST_FIELDS = {
-    'priority':      int,
+    'priority': int,
     'max_queue_size': int,
-    'http_port':     int,
+    'http_port': int,
 }
 
 _PATCHABLE_FIELDS = {
-    'ae_title':      str,
-    'host':          str,
-    'port':          int,
-    'priority':      int,
+    'ae_title': str,
+    'host': str,
+    'port': int,
+    'priority': int,
     'max_queue_size': int,
-    'http_port':     int,
+    'http_port': int,
 }
 
 _DEST_ALLOWED_FIELDS = set(_PATCHABLE_FIELDS) | {'name'}
@@ -35,19 +35,19 @@ def get_router():
 
 def _dest_to_dict(dest, *, full=False):
     d = {
-        'name':      dest.name,
-        'ae_title':  dest.ae_title,
-        'host':      dest.host,
-        'port':      dest.port,
-        'priority':  dest.priority,
-        'status':    dest.status.value,
-        'load':      dest.load_factor,
-        'score':     dest.calculate_score(),
+        'name': dest.name,
+        'ae_title': dest.ae_title,
+        'host': dest.host,
+        'port': dest.port,
+        'priority': dest.priority,
+        'status': dest.status.value,
+        'load': dest.load_factor,
+        'score': dest.calculate_score(),
     }
     if full:
-        d['current_queue']   = dest.current_queue
-        d['max_queue_size']  = dest.max_queue_size
-        d['http_port']       = dest.http_port
+        d['current_queue'] = dest.current_queue
+        d['max_queue_size'] = dest.max_queue_size
+        d['http_port'] = dest.http_port
     return d
 
 
@@ -58,24 +58,19 @@ def _serialize_destination_stats(destinations):
         if isinstance(d, dict):
             serialized.append(d)
             continue
-        serialized.append({
-            'name': d.name,
-            'ae_title': d.ae_title,
-            'host': d.host,
-            'port': d.port,
-            'http_port': getattr(d, 'http_port', None),
-            'priority': d.priority,
-            'status': d.status.value,
-            'load': getattr(d, 'load_factor', None),
-            'score': d.calculate_score() if hasattr(d, 'calculate_score') else None,
-        })
+        try:
+            serialized.append(_dest_to_dict(d, full=True))
+        except Exception as e:
+            current_app.logger.exception(
+                f"Failed to serialize destination object: {e}"
+            )
     return serialized
 
 
 def _validate_int_positive(value, field):
     if not isinstance(value, int) or isinstance(value, bool):
         return None, f"'{field}' must be an integer, got {value!r}"
-    if value <= 0:
+    if value < 0:
         return None, f"'{field}' must be a positive integer, got {value}"
     return value, None
 
@@ -89,7 +84,6 @@ def _validate_optional_port(value, field):
     return v, None
 
 
-# ✅ FIX: reuse optional validator
 def _validate_port(value):
     return _validate_optional_port(value, 'port')
 
@@ -133,8 +127,13 @@ def get_stats():
 
     if isinstance(stats, dict) and 'destinations' in stats and stats['destinations'] is not None:
         try:
-            stats['destinations'] = _serialize_destination_stats(stats['destinations'])
-        except Exception:
+            stats['destinations'] = _serialize_destination_stats(
+                stats['destinations']
+            )
+        except Exception as e:
+            current_app.logger.exception(
+                f"Failed to serialize destinations list: {e}"
+            )
             stats['destinations'] = []
 
     return jsonify(stats), 200
@@ -148,7 +147,6 @@ def list_destinations():
 
     destinations = router.destination_manager.get_all_destinations()
 
-    # ✅ FIX: reuse serializer
     return jsonify({
         'destinations': _serialize_destination_stats(destinations)
     }), 200
@@ -185,7 +183,9 @@ def add_destination():
     name = body['name']
 
     if not re.match(r'^[A-Za-z0-9_\-\.]+$', name):
-        return jsonify({'error': "'name' must contain only letters, digits, hyphens, underscores, or dots"}), 400
+        return jsonify({
+            'error': "'name' must contain only letters, digits, hyphens, underscores, or dots"
+        }), 400
 
     if router.destination_manager.get_destination(name):
         return jsonify({'error': f"Destination '{name}' already exists"}), 409
@@ -227,7 +227,10 @@ def remove_destination(name):
         return jsonify({'error': f"Destination '{name}' not found"}), 404
 
     router.destination_manager.remove_destination(name)
-    return jsonify({'message': f"Destination '{name}' removed successfully"}), 200
+
+    return jsonify({
+        'message': f"Destination '{name}' removed successfully"
+    }), 200
 
 
 @routing_bp.route('/destinations/<name>', methods=['PATCH'])
@@ -262,15 +265,21 @@ def update_destination(name):
         return jsonify({'error': str(e)}), 400
 
     updates = {}
+
     for field in body:
+        if field not in _PATCHABLE_FIELDS:
+            continue
+
         if field in ('ae_title', 'host', 'port'):
             updates[field] = validated[field]
-        elif field in _PATCHABLE_FIELDS and _PATCHABLE_FIELDS[field] is int:
+
+        elif _PATCHABLE_FIELDS[field] is int:
             validator = _validate_optional_port if field == 'http_port' else _validate_int_positive
             val, err = validator(body[field], field)
             if err:
                 return jsonify({'error': err}), 400
             updates[field] = val
+
         else:
             if not isinstance(body[field], str) or not body[field].strip():
                 return jsonify({'error': f"'{field}' must be a non-empty string"}), 400

--- a/Diomedex/routing/routes.py
+++ b/Diomedex/routing/routes.py
@@ -265,7 +265,7 @@ def update_destination(name):
     for field in body:
         if field in ('ae_title', 'host', 'port'):
             updates[field] = validated[field]
-        elif _PATCHABLE_FIELDS[field] is int:
+        elif field in _PATCHABLE_FIELDS and _PATCHABLE_FIELDS[field] is int:
             validator = _validate_optional_port if field == 'http_port' else _validate_int_positive
             val, err = validator(body[field], field)
             if err:

--- a/Diomedex/routing/routes.py
+++ b/Diomedex/routing/routes.py
@@ -63,6 +63,7 @@ def _serialize_destination_stats(destinations):
             'ae_title': d.ae_title,
             'host': d.host,
             'port': d.port,
+            'http_port': getattr(d, 'http_port', None),
             'priority': d.priority,
             'status': d.status.value,
             'load': getattr(d, 'load_factor', None),

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -174,6 +174,29 @@ class TestStatsRoute:
         for key in ('total_received', 'total_routed', 'total_failed', 'destinations'):
             assert key in data, f"missing key: {key}"
 
+    def test_stats_preserves_pre_serialized_destination_dicts(self, client, app):
+        router, _ = _make_router()
+        router.get_stats.return_value = {
+            'total_received': 1,
+            'total_routed': 1,
+            'total_failed': 0,
+            'destinations': [{
+                'name': 'orthanc-a',
+                'ae_title': 'ORTHANC_A',
+                'host': '127.0.0.1',
+                'port': 4242,
+                'priority': 1,
+                'status': 'healthy',
+                'load': 0.0,
+                'score': 12.0,
+            }],
+        }
+        app.dicom_router = router
+
+        data = client.get('/routing/stats').get_json()
+        assert len(data['destinations']) == 1
+        assert data['destinations'][0]['name'] == 'orthanc-a'
+
     def test_stats_router_unavailable(self, client, app):
         assert client.get('/routing/stats').status_code == 503
 
@@ -235,6 +258,13 @@ class TestPostDestinationRoute:
         manager.get_destination.return_value = None
         app.dicom_router = router
         rv = self._post(client, {**self._VALID, 'port': 99999})
+        assert rv.status_code == 400
+
+    def test_http_port_above_65535_returns_400(self, client, app):
+        router, manager = _make_router()
+        manager.get_destination.return_value = None
+        app.dicom_router = router
+        rv = self._post(client, {**self._VALID, 'http_port': 99999})
         assert rv.status_code == 400
 
     def test_unsafe_name_returns_400(self, client, app):
@@ -337,6 +367,12 @@ class TestPatchDestinationRoute:
         router, _ = _make_router(dest=_make_dest())
         app.dicom_router = router
         rv = self._patch(client, 'orthanc-a', {'port': 99999})
+        assert rv.status_code == 400
+
+    def test_patch_http_port_above_65535_returns_400(self, client, app):
+        router, _ = _make_router(dest=_make_dest())
+        app.dicom_router = router
+        rv = self._patch(client, 'orthanc-a', {'http_port': 99999})
         assert rv.status_code == 400
 
     def test_router_unavailable_returns_503(self, client, app):


### PR DESCRIPTION
Added strict range validation for optional http_port (must be 1..65535) via a focused helper _validate_optional_port, then applied it in both POST /routing/destinations and PATCH /routing/destinations/<name>. This keeps current architecture and APIs unchanged while preventing invalid runtime configuration values like 99999. 

Added regression tests for both create and patch paths to verify that out-of-range http_port values now return 400.