### PR TITLE
update the documentation for POST, DELETE, and PATCH endpoints

### DIFF
--- a/Diomedex/routing/README.md
+++ b/Diomedex/routing/README.md
@@ -40,6 +40,97 @@ router.route_dataset(dicom_dataset)
 - `GET /routing/destinations` - List all destinations
 - `GET /routing/destinations/<name>` - Get specific destination info
 
+### `POST /routing/destinations`
+
+Registers a new DICOM destination endpoint dynamically without requiring a service restart.
+
+**Request Body (`application/json`):**
+
+```json
+{
+  "name": "destination_name",    // Required: string
+  "ae_title": "AE_TITLE",        // Required: string
+  "host": "192.168.1.10",        // Required: string
+  "port": 104,                   // Required: integer (1-65535)
+  "priority": 1,                 // Optional: positive integer
+  "max_queue_size": 100,         // Optional: positive integer
+  "http_port": 8042              // Optional: positive integer
+}
+```
+
+**Response (`201 Created`):**
+
+```json
+{
+  "message": "Destination 'destination_name' added successfully",
+  "destination": {
+    "name": "destination_name",
+    "ae_title": "AE_TITLE",
+    "host": "192.168.1.10",
+    "port": 104,
+    "priority": 1,
+    "status": "online",
+    "load": 0.0,
+    "score": 1.0,
+    "current_queue": 0,
+    "max_queue_size": 100,
+    "http_port": 8042
+  }
+}
+```
+
+### `DELETE /routing/destinations/<name>`
+
+Unregisters and removes a specified DICOM destination endpoint.
+
+**Response (`200 OK`):**
+
+```json
+{
+  "message": "Destination '<name>' removed successfully"
+}
+```
+
+### `PATCH /routing/destinations/<name>`
+
+Modifies the configuration of an existing DICOM destination endpoint dynamically.
+
+**Request Body (`application/json`):**
+
+Include any subset of the following modifiable parameters:
+
+```json
+{
+  "ae_title": "NEW_AE_TITLE",   // Optional: string
+  "host": "192.168.1.11",       // Optional: string
+  "port": 105,                  // Optional: integer (1-65535)
+  "priority": 5,                // Optional: positive integer
+  "max_queue_size": 250,        // Optional: positive integer
+  "http_port": 8043             // Optional: positive integer
+}
+```
+
+**Response (`200 OK`):**
+
+```json
+{
+  "message": "Destination '<name>' updated successfully",
+  "destination": {
+    "name": "<name>",
+    "ae_title": "NEW_AE_TITLE",
+    "host": "192.168.1.11",
+    "port": 105,
+    "priority": 5,
+    "status": "online",
+    "load": 0.0,
+    "score": 5.0,
+    "current_queue": 0,
+    "max_queue_size": 250,
+    "http_port": 8043
+  }
+}
+```
+
 ## Current Status
 
 This is a proof-of-concept implementation. Full DICOM C-STORE functionality requires `pynetdicom` integration.

--- a/Diomedex/routing/README.md
+++ b/Diomedex/routing/README.md
@@ -48,7 +48,7 @@ Registers a new DICOM destination endpoint dynamically without requiring a servi
 
 ```json
 {
-  "name": "destination_name",    // Required: string
+  "name": "destination_name",    // Required: string (letters, digits, hyphens, underscores, dots only)
   "ae_title": "AE_TITLE",        // Required: string
   "host": "192.168.1.10",        // Required: string
   "port": 104,                   // Required: integer (1-65535)
@@ -69,9 +69,9 @@ Registers a new DICOM destination endpoint dynamically without requiring a servi
     "host": "192.168.1.10",
     "port": 104,
     "priority": 1,
-    "status": "online",
+    "status": "healthy",
     "load": 0.0,
-    "score": 1.0,
+    "score": 17.0,
     "current_queue": 0,
     "max_queue_size": 100,
     "http_port": 8042
@@ -121,9 +121,9 @@ Include any subset of the following modifiable parameters:
     "host": "192.168.1.11",
     "port": 105,
     "priority": 5,
-    "status": "online",
+    "status": "healthy",
     "load": 0.0,
-    "score": 5.0,
+    "score": 57.0,
     "current_queue": 0,
     "max_queue_size": 250,
     "http_port": 8043


### PR DESCRIPTION
- Added POST /routing/destinations`with request schemas for registering endpoints at runtime.
- Added DELETE /routing/destinations/<name> for unregistering endpoints.
- Added PATCH /routing/destinations/<name> for dynamically reloading configuration parameters without downtime.
- Ensured all endpoints have explicit JSON request/response shapes and professional HTTP status code mapping.

This closes #120 