### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,3 +13,4 @@ setup(
         'requests>=2.26.0',
         'pandas>=1.3.0'
     ],
+)

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,3 @@ setup(
         'requests>=2.26.0',
         'pandas>=1.3.0'
     ],
-    entry_points={
-        'console_scripts': [
-            'diomede=diomede.cli:main',
-        ],
-    },
-)


### PR DESCRIPTION
## Summary
Fixes an invalid console entry point in `setup.py` that references a non-existent module.

## What Changed
- Updated or removed the `console_scripts` entry pointing to `diomede.cli:main`.
- Ensured the entry point either maps to a valid module or is removed if no CLI exists.

## Why
The existing entry point points to a module that does not exist, causing immediate failure when invoking the CLI after package installation.

## Scope
- setup.py (entry_points section only)

## Risk
Very low — change is limited to package configuration and does not affect runtime logic.