### PR TITLE
Handle malformed file info

### DIFF
--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -19,6 +19,8 @@ class DICOMAlbumCreator:
                 if ds is None:
                     continue
 
+                # Use safe .get field access and defaults for partially broken datasets
+                # .get is explicit and avoids reflection-style behaviors.
                 dicom_files.append({
                     'path': str(dcm_path),
                     'patient_id': ds.get('PatientID', ''),
@@ -30,12 +32,7 @@ class DICOMAlbumCreator:
     def create_album_index(self, files: List[Dict]) -> bool:
         """Index DICOM files in database"""
         try:
-            unique_paths = list({
-                file_info.get('path')
-                for file_info in files
-                if isinstance(file_info, dict) and file_info.get('path')
-            })
-
+            unique_paths = list({file_info.get('path') for file_info in files if file_info.get('path')})
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):
                 chunk = unique_paths[i:i + 500]
@@ -45,10 +42,8 @@ class DICOMAlbumCreator:
                     .filter(DICOMFile.file_path.in_(chunk))
                     .all()
                 )
-
             count = 0
             for file_info in files:
-                # Skip malformed entries safely
                 if not isinstance(file_info, dict):
                     LOG.warning("Skipping non-dict file_info entry: %r", file_info)
                     continue
@@ -57,7 +52,6 @@ class DICOMAlbumCreator:
                 if not isinstance(path, str) or not path.strip():
                     LOG.warning("Skipping file_info with invalid path: %r", file_info)
                     continue
-
                 if path not in existing_paths:
                     dicom_file = DICOMFile(
                         file_path=path,
@@ -68,14 +62,11 @@ class DICOMAlbumCreator:
                     db.session.add(dicom_file)
                     existing_paths.add(path)
                     count += 1
-
                     if count % 500 == 0:
                         db.session.commit()
-
             db.session.commit()
             return True
-
-        except Exception:
+        except Exception as e:
             db.session.rollback()
-            LOG.exception("Error indexing files")
+            print(f"Error indexing files: {str(e)}")
             return False

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -54,7 +54,7 @@ class DICOMAlbumCreator:
                     continue
 
                 path = file_info.get('path')
-                if not isinstance(path, str) or not path.strip():
+                if not isinstance(path, str) or not (path := path.strip()):
                     LOG.warning("Skipping file_info entry with missing or invalid path")
                     continue
                 if path not in existing_paths:

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -45,7 +45,7 @@ class DICOMAlbumCreator:
             count = 0
             for file_info in files:
                 if not isinstance(file_info, dict):
-                    LOG.warning("Skipping non-dict file_info entry: %r", file_info)
+                    LOG.warning("Skipping malformed file_info entry (not a dictionary)")
                     continue
 
                 path = file_info.get('path')

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -33,10 +33,11 @@ class DICOMAlbumCreator:
         """Index DICOM files in database"""
         try:
             unique_paths = list({
-                                    file_info.get('path')
-                                    for file_info in files
-                                    if isinstance(file_info, dict) and file_info.get('path')
-                                })
+                path for file_info in files
+                if isinstance(file_info, dict)
+                and isinstance(path := file_info.get('path'), str)
+                and path.strip()
+            })
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):
                 chunk = unique_paths[i:i + 500]

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -33,10 +33,10 @@ class DICOMAlbumCreator:
         """Index DICOM files in database"""
         try:
             unique_paths = list({
-                path for file_info in files
+                p for file_info in files
                 if isinstance(file_info, dict)
                 and isinstance(path := file_info.get('path'), str)
-                and path.strip()
+                and (p := path.strip())
             })
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -50,7 +50,7 @@ class DICOMAlbumCreator:
 
                 path = file_info.get('path')
                 if not isinstance(path, str) or not path.strip():
-                    LOG.warning("Skipping file_info with invalid path: %r", file_info)
+                    LOG.warning("Skipping file_info entry with missing or invalid path")
                     continue
                 if path not in existing_paths:
                     dicom_file = DICOMFile(

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -32,7 +32,11 @@ class DICOMAlbumCreator:
     def create_album_index(self, files: List[Dict]) -> bool:
         """Index DICOM files in database"""
         try:
-            unique_paths = list({file_info.get('path') for file_info in files if file_info.get('path')})
+            unique_paths = list({
+                                    file_info.get('path')
+                                    for file_info in files
+                                    if isinstance(file_info, dict) and file_info.get('path')
+                                })
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):
                 chunk = unique_paths[i:i + 500]

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -19,8 +19,6 @@ class DICOMAlbumCreator:
                 if ds is None:
                     continue
 
-                # Use safe .get field access and defaults for partially broken datasets
-                # .get is explicit and avoids reflection-style behaviors.
                 dicom_files.append({
                     'path': str(dcm_path),
                     'patient_id': ds.get('PatientID', ''),
@@ -32,7 +30,12 @@ class DICOMAlbumCreator:
     def create_album_index(self, files: List[Dict]) -> bool:
         """Index DICOM files in database"""
         try:
-            unique_paths = list({file_info.get('path') for file_info in files if file_info.get('path')})
+            unique_paths = list({
+                file_info.get('path')
+                for file_info in files
+                if isinstance(file_info, dict) and file_info.get('path')
+            })
+
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):
                 chunk = unique_paths[i:i + 500]
@@ -42,11 +45,19 @@ class DICOMAlbumCreator:
                     .filter(DICOMFile.file_path.in_(chunk))
                     .all()
                 )
+
             count = 0
             for file_info in files:
-                path = file_info.get('path')
-                if not path:
+                # Skip malformed entries safely
+                if not isinstance(file_info, dict):
+                    LOG.warning("Skipping non-dict file_info entry: %r", file_info)
                     continue
+
+                path = file_info.get('path')
+                if not isinstance(path, str) or not path.strip():
+                    LOG.warning("Skipping file_info with invalid path: %r", file_info)
+                    continue
+
                 if path not in existing_paths:
                     dicom_file = DICOMFile(
                         file_path=path,
@@ -57,11 +68,14 @@ class DICOMAlbumCreator:
                     db.session.add(dicom_file)
                     existing_paths.add(path)
                     count += 1
+
                     if count % 500 == 0:
                         db.session.commit()
+
             db.session.commit()
             return True
-        except Exception as e:
+
+        except Exception:
             db.session.rollback()
-            print(f"Error indexing files: {str(e)}")
+            LOG.exception("Error indexing files")
             return False


### PR DESCRIPTION
### Summary

Improves robustness and safety of input handling in `create_album_index` by preventing crashes from malformed inputs and avoiding logging of potentially sensitive data.

### Changes

* Added type checking during `unique_paths` construction to ensure only dictionary entries are processed, preventing `AttributeError` when encountering invalid inputs
* Introduced validation for `file_info` entries inside the processing loop:

  * Skip non-dictionary entries
  * Skip entries with missing or invalid `path` values
* Updated logging messages to avoid including raw `file_info` data, reducing risk of exposing sensitive information

### Motivation

Previously, malformed entries in `files` could cause runtime errors during path extraction. Additionally, logging raw input data could expose sensitive information. These changes ensure safer and more resilient handling of input data while maintaining existing behavior.

Note
This PR supersedes earlier attempts and focuses on a minimal, scoped fix.
Some minor whitespace/line movement changes may appear in the diff due to code insertion, but no functional changes are associated with those lines.
