### PR TITLE
Fix race condition in HealthChecker start/stop lifecycle

### DIFF
--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -23,11 +23,11 @@ class HealthChecker:
             if self.running or (self._thread and self._thread.is_alive()):
                 return
             
-            self.running = True
             self._stop_event = Event()
 
             self._thread = Thread(target=self._check_loop, daemon=True)
             self._thread.start()
+            self.running = True
     
     def stop(self):
         with self._lifecycle_lock:

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -31,7 +31,7 @@ class HealthChecker:
     
     def stop(self):
         with self._lifecycle_lock:
-            if not self.running:
+            if not self.running and not (self._thread and self._thread.is_alive()):
                 return
             
             self.running = False

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -23,7 +23,7 @@ class HealthChecker:
             if self._thread and self._thread.is_alive():
                 return
             
-            self._stop_event = Event()
+            self._stop_event.clear()
 
             self._thread = Thread(target=self._check_loop, daemon=True)
             self._thread.start()

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -21,7 +21,10 @@ class HealthChecker:
         with self._lifecycle_lock:
             # Prevent duplicate or zombie threads
             if self._thread and self._thread.is_alive():
-                return
+                if not self._stop_event.is_set():
+                    return
+                # Wait for the stopping thread to finish before starting a new one
+                self._thread.join(timeout=5)
             
             self._stop_event.clear()
 

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -20,7 +20,7 @@ class HealthChecker:
     def start(self):
        
         with self._lifecycle_lock:
-            if self.running:
+            if self.running or (self._thread and self._thread.is_alive()):
                 return
             
             self.running = True

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -1,7 +1,8 @@
 import time
 import requests
 import logging
-from threading import Thread, Event
+from threading import Thread, Event, Lock  
+
 from .destinations import DestinationManager, DestinationStatus
 
 logger = logging.getLogger(__name__)
@@ -14,24 +15,32 @@ class HealthChecker:
         self.running = False
         self._stop_event = Event()
         self._thread = None
+        self._lifecycle_lock = Lock()  
     
     def start(self):
-        if self.running:
-            return
-        
-        self.running = True
-        self._stop_event.clear()
-        self._thread = Thread(target=self._check_loop, daemon=True)
-        self._thread.start()
+       
+        with self._lifecycle_lock:
+            if self.running:
+                return
+            
+            self.running = True
+            self._stop_event.clear()
+            self._thread = Thread(target=self._check_loop, daemon=True)
+            self._thread.start()
     
     def stop(self):
-        if not self.running:
-            return
+      
+        with self._lifecycle_lock:
+            if not self.running:
+                return
+            
+            self.running = False
+            self._stop_event.set()
+            thread = self._thread  
         
-        self.running = False
-        self._stop_event.set()
-        if self._thread:
-            self._thread.join(timeout=5)
+       
+        if thread:
+            thread.join(timeout=5)
     
     def _check_loop(self):
         while not self._stop_event.is_set():

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -18,16 +18,22 @@ class HealthChecker:
         self._lifecycle_lock = Lock()  
     
     def start(self):
+        thread_to_join = None
+
         with self._lifecycle_lock:
-            # Prevent duplicate or zombie threads
+            if self.running:
+                return
+
             if self._thread and self._thread.is_alive():
                 if not self._stop_event.is_set():
                     return
-                # Wait for the stopping thread to finish before starting a new one
-                self._thread.join(timeout=5)
-            
-            self._stop_event.clear()
+                thread_to_join = self._thread
 
+        if thread_to_join:
+            thread_to_join.join(timeout=5)
+
+        with self._lifecycle_lock:
+            self._stop_event.clear()
             self._thread = Thread(target=self._check_loop, daemon=True)
             self._thread.start()
             self.running = True
@@ -39,12 +45,10 @@ class HealthChecker:
             
             self.running = False
 
-            # signal current thread to stop
             self._stop_event.set()
 
             thread = self._thread
         
-        # join outside lock
         if thread:
             thread.join(timeout=5)
     

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -18,27 +18,31 @@ class HealthChecker:
         self._lifecycle_lock = Lock()  
     
     def start(self):
-       
         with self._lifecycle_lock:
+            # Prevent duplicate or zombie threads
             if self.running or (self._thread and self._thread.is_alive()):
                 return
             
             self.running = True
-            self._stop_event.clear()
+            self._stop_event = Event()
+
             self._thread = Thread(target=self._check_loop, daemon=True)
             self._thread.start()
     
     def stop(self):
-      
         with self._lifecycle_lock:
             if not self.running:
                 return
             
             self.running = False
+
+            # signal current thread to stop
             self._stop_event.set()
-            thread = self._thread  
+
+            thread = self._thread
+            self._thread = None  
         
-       
+        # join outside lock
         if thread:
             thread.join(timeout=5)
     
@@ -67,9 +71,6 @@ class HealthChecker:
         start = time.time()
         
         try:
-            # Try HTTP health check for Orthanc
-            # TODO: use pynetdicom C-ECHO for real DICOM verification
-            # Note: Orthanc HTTP API typically on different port (e.g., 8042) than DICOM port
             url = f"http://{dest.host}:{dest.http_port}/system"
             response = requests.get(url, timeout=self.request_timeout)
             response_time = time.time() - start

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -40,7 +40,6 @@ class HealthChecker:
             self._stop_event.set()
 
             thread = self._thread
-            self._thread = None  
         
         # join outside lock
         if thread:

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -20,7 +20,7 @@ class HealthChecker:
     def start(self):
         with self._lifecycle_lock:
             # Prevent duplicate or zombie threads
-            if self.running or (self._thread and self._thread.is_alive()):
+            if self._thread and self._thread.is_alive():
                 return
             
             self._stop_event = Event()

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -70,6 +70,9 @@ class HealthChecker:
         start = time.time()
         
         try:
+            # Try HTTP health check for Orthanc
+            # TODO: use pynetdicom C-ECHO for real DICOM verification
+            # Note: Orthanc HTTP API typically on different port (e.g., 8042) than DICOM port
             url = f"http://{dest.host}:{dest.http_port}/system"
             response = requests.get(url, timeout=self.request_timeout)
             response_time = time.time() - start


### PR DESCRIPTION
### Summary

Fixes a race condition in the `HealthChecker` lifecycle methods by making `start()` and `stop()` thread-safe.

### Changes

* Introduced a `_lifecycle_lock` to synchronize access to `start()` and `stop()`
* Ensured that only one thread can modify the `running` state at a time
* Moved thread joining (`join()`) outside the lock to avoid blocking and potential deadlocks

### Motivation

The previous implementation accessed the `running` flag without synchronization, which could lead to multiple threads being started or inconsistent lifecycle behavior when `start()` or `stop()` were called concurrently.

### Scope

This change is limited to improving thread safety in the `HealthChecker` lifecycle and does not modify health check logic or external behavior.
