### PR TITLE
Handle invalid JSON gracefully in album routes

### DIFF
--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -10,7 +10,7 @@ albums_bp = Blueprint('albums', __name__)
 def scan_directory():
     """Scan directory for DICOM files"""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
         if not data or 'path' not in data:
             return jsonify({'error': 'Path parameter is required'}), 400
         
@@ -51,7 +51,7 @@ def scan_directory():
 def create_album():
     """Create a new DICOM album"""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
         if not data or 'name' not in data:
             return jsonify({'error': 'Name is required'}), 400
         


### PR DESCRIPTION
## Summary
Use `request.get_json(silent=True)` in album routes to gracefully handle malformed or non-JSON request bodies.

## Changes
- Updated `scan_directory` and `create_album` routes to use:
  - `request.get_json(silent=True)` instead of `request.get_json()`

## Motivation
Previously, malformed JSON could trigger Flask's default BadRequest exception, potentially returning non-JSON (HTML) error responses.

With this change:
- Invalid or non-JSON bodies return `None`
- Existing validation (`if not data`) handles these cases cleanly
- API consistently returns JSON error responses

## Behavior
-  No change for valid requests
-  Invalid JSON now results in structured JSON error responses instead of Flask default errors
-  No impact on existing clients

## Risk
Low: this only affects how malformed input is handled and does not change successful request flows.