### PR TITLE
fix: improve dicom handling efficiency and add compatibility fallback

### DIFF
--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -58,8 +58,10 @@ def _ensure_required_tags(file_path: str) -> str:
         if tmp_path:
             try:
                 Path(tmp_path).unlink()
-            except OSError:
+            except FileNotFoundError:
                 pass
+            except OSError as e:
+                LOG.warning("Failed to delete temporary file %s: %s", tmp_path, e)
         raise
 
 
@@ -130,8 +132,10 @@ class DICOMAnonymizer:
             for tmp in temp_files:
                 try:
                     Path(tmp).unlink()
-                except OSError:
+                except FileNotFoundError:
                     pass
+                except OSError as e:
+                    LOG.warning("Failed to delete temporary file %s: %s", tmp, e)
 
         skipped_pkl = dest / "skipped.pkl"
         if skipped_pkl.exists():

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -58,7 +58,7 @@ def _ensure_required_tags(file_path: str) -> str:
         if tmp_path:
             try:
                 Path(tmp_path).unlink()
-            except FileNotFoundError:
+            except OSError:
                 pass
         raise
 
@@ -130,7 +130,7 @@ class DICOMAnonymizer:
             for tmp in temp_files:
                 try:
                     Path(tmp).unlink()
-                except FileNotFoundError:
+                except OSError:
                     pass
 
         skipped_pkl = dest / "skipped.pkl"

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -56,11 +56,10 @@ def _ensure_required_tags(file_path: str) -> str:
 
     except Exception:
         if tmp_path:
-            if tmp_path:
-                try:
-                    Path(tmp_path).unlink()
-                except FileNotFoundError:
-                    pass
+            try:
+                Path(tmp_path).unlink()
+            except FileNotFoundError:
+                pass
         raise
 
 

--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -48,12 +48,19 @@ def _ensure_required_tags(file_path: str) -> str:
         with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
             tmp_path = tmp.name
 
-        ds.save_as(tmp_path, write_like_original=False)
+        try:
+            ds.save_as(tmp_path, write_like_original=False)
+        except TypeError:
+            ds.save_as(tmp_path)
         return tmp_path
 
     except Exception:
         if tmp_path:
-            Path(tmp_path).unlink(missing_ok=True)
+            if tmp_path:
+                try:
+                    Path(tmp_path).unlink()
+                except FileNotFoundError:
+                    pass
         raise
 
 
@@ -122,7 +129,10 @@ class DICOMAnonymizer:
             _niffler_dcm_anonymize(patched_files, str(dest))
         finally:
             for tmp in temp_files:
-                Path(tmp).unlink(missing_ok=True)
+                try:
+                    Path(tmp).unlink()
+                except FileNotFoundError:
+                    pass
 
         skipped_pkl = dest / "skipped.pkl"
         if skipped_pkl.exists():


### PR DESCRIPTION
continuing from the previous pr, gemini pointed out potential compatibility issues with python versions<3.8 and older versions of pydicom
in `Diomedex/anonymization/core.py`, we had
```python
Path(tmp_path).unlink(missing_ok=True)
```
```python
ds.save_as(tmp_path, write_like_original=False)
```
i have updated the temp file cleanup logic to avoid `missing_ok=True` and added a compatibility fallback for `save_as`

with this, i have ensured compatibility with python versions prior to 3.8 and maintained safe and race condition free file cleanup