### PR TITLE
Fix/albums request validation and error handling

### DIFF
--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -58,8 +58,12 @@ def create_album():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not isinstance(data.get('name'), str):
-            return jsonify({'error': 'Name is required and must be a string'}), 400
+        if not isinstance(data.get('name'), str) or not data.get('name', '').strip():
+            return jsonify({'error': 'Name is required and must be a non-empty string'}), 400
+        if len(data.get('name', '')) > 100:
+            return jsonify({'error': 'Name must be 100 characters or less'}), 400
+        if 'description' in data and not isinstance(data.get('description'), str):
+            return jsonify({'error': 'Description must be a string'}), 400
         
         # Initialize kheops adapter with error handling for missing config
         try:

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -46,8 +46,9 @@ def scan_directory():
                 'files': files[:10]  # Return first 10 for preview
             })
         return jsonify({'error': 'Failed to index files'}), 500
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+    current_app.logger.exception('Directory scan failed')
+    return jsonify({'error': 'Internal server error'}), 500
 
 
 @albums_bp.route('/create', methods=['POST'])

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -91,7 +91,7 @@ def create_album():
                 'share_url': new_album.share_url
             }
         })
-    except Exception as e:
+    except Exception:
         db.session.rollback()
         current_app.logger.exception('Album creation failed')
         return jsonify({'error': 'Internal server error'}), 500

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -10,7 +10,9 @@ albums_bp = Blueprint('albums', __name__)
 def scan_directory():
     """Scan directory for DICOM files"""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'Invalid JSON body'}), 400
         if not data or 'path' not in data:
             return jsonify({'error': 'Path parameter is required'}), 400
         
@@ -47,11 +49,14 @@ def scan_directory():
     except Exception as e:
         return jsonify({'error': str(e)}), 500
 
+
 @albums_bp.route('/create', methods=['POST'])
 def create_album():
     """Create a new DICOM album"""
     try:
-        data = request.get_json()
+        data = request.get_json(silent=True)
+        if not isinstance(data, dict):
+            return jsonify({'error': 'Invalid JSON body'}), 400
         if not data or 'name' not in data:
             return jsonify({'error': 'Name is required'}), 400
         
@@ -61,6 +66,7 @@ def create_album():
         except KeyError as e:
             current_app.logger.error(f'Kheops configuration missing: {e}')
             return jsonify({'error': 'Integration service is not configured.'}), 500
+
         # Create in Kheops
         album = kheops.create_album(data['name'], data.get('description', ''))
         if not album:
@@ -86,4 +92,5 @@ def create_album():
         })
     except Exception as e:
         db.session.rollback()
-        return jsonify({'error': str(e)}), 500
+        current_app.logger.exception('Album creation failed')
+        return jsonify({'error': 'Internal server error'}), 500

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -13,7 +13,8 @@ def scan_directory():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not isinstance(data.get('path'), str) or not data.get('path', '').strip():
+        path = data.get('path')
+        if not isinstance(path, str) or not path.strip():
             return jsonify({'error': 'Path parameter is required and must be a non-empty string'}), 400
         
         # Get and validate configuration

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -57,8 +57,8 @@ def create_album():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not data or 'name' not in data:
-            return jsonify({'error': 'Name is required'}), 400
+        if not isinstance(data.get('name'), str):
+            return jsonify({'error': 'Name is required and must be a string'}), 400
         
         # Initialize kheops adapter with error handling for missing config
         try:

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -13,8 +13,8 @@ def scan_directory():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not data or 'path' not in data:
-            return jsonify({'error': 'Path parameter is required'}), 400
+        if not isinstance(data.get('path'), str):
+            return jsonify({'error': 'Path parameter is required and must be a string'}), 400
         
         # Get and validate configuration
         storage_path = current_app.config.get('STORAGE_PATH')

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -70,7 +70,9 @@ def create_album():
         if len(name) > 100:
             return jsonify({'error': 'Name must be 100 characters or less'}), 400
         
-        description = data.get('description', '')
+        description = data.get('description')
+        if description is None:
+            description = ''
         if not isinstance(description, str):
             return jsonify({'error': 'Description must be a string'}), 400
         

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -47,8 +47,8 @@ def scan_directory():
             })
         return jsonify({'error': 'Failed to index files'}), 500
     except Exception:
-    current_app.logger.exception('Directory scan failed')
-    return jsonify({'error': 'Internal server error'}), 500
+        current_app.logger.exception('Directory scan failed')
+        return jsonify({'error': 'Internal server error'}), 500
 
 
 @albums_bp.route('/create', methods=['POST'])

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -108,4 +108,4 @@ def create_album():
     except Exception:
         db.session.rollback()
         current_app.logger.exception("Unhandled error in /create")
-        return jsonify({'error': 'An internal server error occurred'}), 500
+        return jsonify({'error': 'Internal server error'}), 500

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -13,8 +13,8 @@ def scan_directory():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not isinstance(data.get('path'), str):
-            return jsonify({'error': 'Path parameter is required and must be a string'}), 400
+        if not isinstance(data.get('path'), str) or not data.get('path', '').strip():
+            return jsonify({'error': 'Path parameter is required and must be a non-empty string'}), 400
         
         # Get and validate configuration
         storage_path = current_app.config.get('STORAGE_PATH')

--- a/Diomedex/albums/routes.py
+++ b/Diomedex/albums/routes.py
@@ -13,6 +13,7 @@ def scan_directory():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
+
         path = data.get('path')
         if not isinstance(path, str) or not path.strip():
             return jsonify({'error': 'Path parameter is required and must be a non-empty string'}), 400
@@ -23,7 +24,7 @@ def scan_directory():
             current_app.logger.error("'STORAGE_PATH' is not configured.")
             return jsonify({'error': 'Server configuration error.'}), 500
         
-        user_path = Path(data['path'])
+        user_path = Path(path)
         storage_base = Path(storage_path).resolve()
         
         # Ensure the user path is absolute and resolve it
@@ -40,13 +41,16 @@ def scan_directory():
         # Initialize creator with config from current_app
         creator = DICOMAlbumCreator(storage_path)
         files = creator.scan_directory(str(user_path))
+
         if creator.create_album_index(files):
             return jsonify({
                 'status': 'success',
                 'file_count': len(files),
                 'files': files[:10]  # Return first 10 for preview
             })
+
         return jsonify({'error': 'Failed to index files'}), 500
+
     except Exception:
         current_app.logger.exception('Directory scan failed')
         return jsonify({'error': 'Internal server error'}), 500
@@ -59,11 +63,15 @@ def create_album():
         data = request.get_json(silent=True)
         if not isinstance(data, dict):
             return jsonify({'error': 'Invalid JSON body'}), 400
-        if not isinstance(data.get('name'), str) or not data.get('name', '').strip():
+
+        name = data.get('name')
+        if not isinstance(name, str) or not name.strip():
             return jsonify({'error': 'Name is required and must be a non-empty string'}), 400
-        if len(data.get('name', '')) > 100:
+        if len(name) > 100:
             return jsonify({'error': 'Name must be 100 characters or less'}), 400
-        if 'description' in data and not isinstance(data.get('description'), str):
+        
+        description = data.get('description', '')
+        if not isinstance(description, str):
             return jsonify({'error': 'Description must be a string'}), 400
         
         # Initialize kheops adapter with error handling for missing config
@@ -74,14 +82,14 @@ def create_album():
             return jsonify({'error': 'Integration service is not configured.'}), 500
 
         # Create in Kheops
-        album = kheops.create_album(data['name'], data.get('description', ''))
+        album = kheops.create_album(name, description)
         if not album:
             return jsonify({'error': 'Failed to create Kheops album'}), 500
             
         # Save to local database
         new_album = Album(
-            name=data['name'],
-            description=data.get('description', ''),
+            name=name,
+            description=description,
             kheops_id=album.get('album_id'),
             share_url=album.get('viewer_url')
         )
@@ -96,6 +104,7 @@ def create_album():
                 'share_url': new_album.share_url
             }
         })
+
     except Exception:
         db.session.rollback()
         current_app.logger.exception("Unhandled error in /create")


### PR DESCRIPTION
Summary
Follow-up improvements to album route request handling, building on the previous JSON parsing update.

Changes
Added validation to ensure request JSON is a dictionary:
Returns 400 Bad Request for non-object JSON payloads (e.g., list, string)
Improved error handling:
Replaced returning raw exception messages (str(e)) with a generic error response
Added logging using current_app.logger.exception(...) for better debugging
Context
This PR builds on the earlier change that introduced request.get_json(silent=True) for safer JSON parsing.
With that in place, this PR ensures invalid or malformed inputs are handled explicitly and consistently.

Behavior
Valid requests remain unchanged
Invalid JSON structures now return clear 400 responses
Internal errors return a generic message while preserving detailed logs
Risk
Low changes are limited to validation and error handling, with no impact on successful request flows.