### PR TITLE
fix: handle invalid JSON payloads safely and improve request validation

### DIFF
--- a/Diomedex/anonymization/routes.py
+++ b/Diomedex/anonymization/routes.py
@@ -46,8 +46,14 @@ def anonymize_directory():
         200: ``{"status": "success", "stats": {"processed": N, "skipped": N, "failed": N}}``
         400: ``{"error": "..."}`` when ``src`` or ``dest`` is missing.
     """
-    data = request.get_json()
-    if not data or "src" not in data or "dest" not in data:
+    data = request.get_json(silent=True)
+    if data is None:
+        return jsonify({"error": "Invalid or missing JSON payload"}), 400
+
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON payload must be an object"}), 400
+
+    if "src" not in data or "dest" not in data:
         return jsonify({"error": "'src' and 'dest' parameters are required"}), 400
 
     try:


### PR DESCRIPTION
in `Diomedex/anonymization/routes.py`, invalid or malformed json payloads could lead to a 500 error because `request.get_json()` raises an exception when parsing fails

this change switches to `get_json(silent=True)` so that such cases are handled gracefully and return a proper 400 response instead

i also separated the validation logic slightly to distinguish between missing/invalid json and missing required fields (`src` and `dest`)

```python
data = request.get_json(silent=True)
if data is None:
    return jsonify({"error": "Invalid or missing JSON payload"}), 400
if not isinstance(data, dict):
    return jsonify({"error": "JSON payload must be an object"}), 400
if "src" not in data or "dest" not in data:
    return jsonify({"error": "'src' and 'dest' parameters are required"}), 400
```