### PR TITLE
Refine type hints in Kheops adapter return values

### DIFF
--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -25,7 +25,7 @@ class KheopsAdapter:
             current_app.logger.error(f"Kheops API error: {str(e)}")
             return None
 
-    def add_to_album(self, album_id: str, dicom_files: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    def add_to_album(self, album_id: str, dicom_files: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
         """Add DICOM files to Kheops album"""
         try:
             # This is a simplified implementation

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Optional, Dict, Any
+from typing import Optional, Dict
 from flask import current_app
 
 class KheopsAdapter:
@@ -10,7 +10,7 @@ class KheopsAdapter:
             current_app.config['KHEOPS_CLIENT_SECRET']
         )
         
-    def create_album(self, name: str, description: str = "") -> Optional[Dict[str, Any]]:
+    def create_album(self, name: str, description: str = "") -> Optional[Dict]:
         """Create a new album in Kheops"""
         try:
             response = requests.post(
@@ -25,7 +25,7 @@ class KheopsAdapter:
             current_app.logger.error(f"Kheops API error: {str(e)}")
             return None
 
-    def add_to_album(self, album_id: str, dicom_files: list) -> Optional[Dict[str, Any]]:
+    def add_to_album(self, album_id: str, dicom_files: list) -> Optional[Dict]:
         """Add DICOM files to Kheops album"""
         try:
             # This is a simplified implementation

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Optional, Dict
+from typing import Optional, Dict, Any
 from flask import current_app
 
 class KheopsAdapter:
@@ -10,7 +10,7 @@ class KheopsAdapter:
             current_app.config['KHEOPS_CLIENT_SECRET']
         )
         
-    def create_album(self, name: str, description: str = "") -> Optional[Dict]:
+    def create_album(self, name: str, description: str = "") -> Optional[Dict[str, Any]]:
         """Create a new album in Kheops"""
         try:
             response = requests.post(
@@ -25,7 +25,7 @@ class KheopsAdapter:
             current_app.logger.error(f"Kheops API error: {str(e)}")
             return None
 
-    def add_to_album(self, album_id: str, dicom_files: list) -> Optional[Dict]:
+    def add_to_album(self, album_id: str, dicom_files: list) -> Optional[Dict[str, Any]]:
         """Add DICOM files to Kheops album"""
         try:
             # This is a simplified implementation

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Optional, Dict, Any, List
+from typing import Optional, Any
 from flask import current_app
 
 class KheopsAdapter:

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -10,7 +10,7 @@ class KheopsAdapter:
             current_app.config['KHEOPS_CLIENT_SECRET']
         )
         
-    def create_album(self, name: str, description: str = "") -> Optional[Dict[str, Any]]:
+    def create_album(self, name: str, description: str = "") -> Optional[dict[str, Any]]:
         """Create a new album in Kheops"""
         try:
             response = requests.post(

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -1,5 +1,5 @@
 import requests
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 from flask import current_app
 
 class KheopsAdapter:

--- a/Diomedex/albums/kheops.py
+++ b/Diomedex/albums/kheops.py
@@ -25,7 +25,7 @@ class KheopsAdapter:
             current_app.logger.error(f"Kheops API error: {str(e)}")
             return None
 
-    def add_to_album(self, album_id: str, dicom_files: list) -> Optional[Dict[str, Any]]:
+    def add_to_album(self, album_id: str, dicom_files: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
         """Add DICOM files to Kheops album"""
         try:
             # This is a simplified implementation


### PR DESCRIPTION
## Summary
Refine type hints in the Kheops adapter to improve clarity of return types.

## Changes
- Updated return types from `Optional[Dict]` to `Optional[Dict[str, Any]]` in:
  - `create_album`
  - `add_to_album`
- Added `Any` import from `typing`

## Motivation
The previous type hints were overly generic and did not specify key/value structure.  
This change makes return types more explicit, improving readability and static analysis support.

## Behavior
- No change in runtime behavior
- No changes to API responses or logic

## Risk
None — this is a typing-only improvement with no impact on execution.