### PR TITLE
Strengthen fallback SECRET_KEY test with non-null assertions

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,4 +35,6 @@ class TestSecretKeyConfig:
         with _db_patch, patch.dict(os.environ, {}, clear=True):
             app1 = create_app()
             app2 = create_app()
+        assert app1.config['SECRET_KEY']
+        assert app2.config['SECRET_KEY']
         assert app1.config['SECRET_KEY'] != app2.config['SECRET_KEY']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -35,6 +35,6 @@ class TestSecretKeyConfig:
         with _db_patch, patch.dict(os.environ, {}, clear=True):
             app1 = create_app()
             app2 = create_app()
-        assert app1.config['SECRET_KEY']
-        assert app2.config['SECRET_KEY']
+        assert len(app1.config['SECRET_KEY']) == 64
+        assert len(app2.config['SECRET_KEY']) == 64
         assert app1.config['SECRET_KEY'] != app2.config['SECRET_KEY']


### PR DESCRIPTION
## Summary
Improve the fallback SECRET_KEY test by ensuring generated keys are not empty or None.

## Changes
- Added assertions to verify SECRET_KEY is present for both app instances
- Retained existing check to ensure keys differ across calls

## Motivation
The previous test only verified that keys were different, but did not guarantee they were valid (non-empty). This change ensures both correctness and randomness.

## Behavior
- No change to application logic
- Improved test robustness

## Risk
None test-only change