### PR TITLE
Clean up redundant str() usage in anonymization module

### DIFF
--- a/Diomedex/anonymization/core.py
+++ b/Diomedex/anonymization/core.py
@@ -119,7 +119,7 @@ class DICOMAnonymizer:
             # skipped.pkl is written by Niffler's DicomAnonymizer2, a trusted library
             # maintained by the same organization KathiraveluLab. Loading its pickle
             # output is an acceptable risk.
-            with open(str(skipped_pkl), "rb") as f:
+            with open(skipped_pkl, "rb") as f:
                 failed = len(pickle.load(f))
         else:
             failed = 0


### PR DESCRIPTION
## Summary
Remove unnecessary `str()` conversions when working with file paths and logging.