### PR TITLE
Handle all request failures as degraded in health checks

### DIFF
--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -76,7 +76,8 @@ class HealthChecker:
                 self.destination_manager.update_status(name, DestinationStatus.DEGRADED)
                 return False
                 
-        except requests.RequestException:
+        except requests.RequestException as e:
+            logger.error(f"Health check failed for destination '{name}': {e}")
             self.destination_manager.update_status(name, DestinationStatus.DEGRADED)
             return False
             

--- a/Diomedex/routing/health.py
+++ b/Diomedex/routing/health.py
@@ -76,7 +76,7 @@ class HealthChecker:
                 self.destination_manager.update_status(name, DestinationStatus.DEGRADED)
                 return False
                 
-        except requests.Timeout:
+        except requests.RequestException:
             self.destination_manager.update_status(name, DestinationStatus.DEGRADED)
             return False
             


### PR DESCRIPTION
## Summary
Expand exception handling in health checks to catch all request-related failures.