### PR TITLE
Guard invalid scan paths and improve DICOM parsing robustness

### DIFF
--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -12,10 +12,18 @@ class DICOMAlbumCreator:
         
     def scan_directory(self, path: str) -> List[Dict]:
         """Scan a directory for DICOM files and return metadata"""
+        root = Path(path)
+        if not root.exists() or not root.is_dir():
+            LOG.warning("Scan path does not exist or is not a directory: %s", path)
+            return []
         dicom_files = []
-        for dcm_path in Path(path).rglob('*'):
+        for dcm_path in root.rglob('*'):
             if dcm_path.is_file():
-                ds = safe_load_dicom_file(dcm_path)
+                try:
+                    ds = safe_load_dicom_file(dcm_path)
+                except Exception:
+                    LOG.exception("Failed to parse candidate DICOM file: %s", dcm_path)
+                    continue
                 if ds is None:
                     continue
 
@@ -71,7 +79,7 @@ class DICOMAlbumCreator:
                         db.session.commit()
             db.session.commit()
             return True
-        except Exception as e:
+        except Exception:
             db.session.rollback()
-            print(f"Error indexing files: {str(e)}")
+            LOG.exception("Error indexing files")
             return False

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -12,10 +12,23 @@ class DICOMAlbumCreator:
         
     def scan_directory(self, path: str) -> List[Dict]:
         """Scan a directory for DICOM files and return metadata"""
-        root = self.storage_path / path
-        if not root.exists() or not root.is_dir():
-            LOG.warning("Scan path does not exist or is not a directory: %s", root)
+        try:
+            base = self.storage_path.resolve()
+            root = (base / path).resolve()
+
+            # Ensure root stays within storage_path
+            root.relative_to(base)
+
+            if not root.is_dir():
+                raise ValueError
+
+        except (ValueError, RuntimeError):
+            LOG.warning(
+                "Scan path is invalid, unauthorized, or not a directory: %s",
+                path,
+            )
             return []
+
         dicom_files = []
         for dcm_path in root.rglob('*'):
             if dcm_path.is_file():
@@ -24,17 +37,17 @@ class DICOMAlbumCreator:
                 except Exception:
                     LOG.exception("Failed to parse candidate DICOM file: %s", dcm_path)
                     continue
+
                 if ds is None:
                     continue
 
-                # Use safe .get field access and defaults for partially broken datasets
-                # .get is explicit and avoids reflection-style behaviors.
                 dicom_files.append({
                     'path': str(dcm_path),
                     'patient_id': ds.get('PatientID', ''),
                     'study_uid': ds.get('StudyInstanceUID', ''),
                     'modality': ds.get('Modality', ''),
                 })
+
         return dicom_files
 
     def create_album_index(self, files: List[Dict]) -> bool:
@@ -46,6 +59,7 @@ class DICOMAlbumCreator:
                 and isinstance(path := file_info.get('path'), str)
                 and (p := path.strip())
             })
+
             existing_paths = set()
             for i in range(0, len(unique_paths), 500):
                 chunk = unique_paths[i:i + 500]
@@ -55,6 +69,7 @@ class DICOMAlbumCreator:
                     .filter(DICOMFile.file_path.in_(chunk))
                     .all()
                 )
+
             count = 0
             for file_info in files:
                 if not isinstance(file_info, dict):
@@ -65,6 +80,7 @@ class DICOMAlbumCreator:
                 if not isinstance(path, str) or not (path := path.strip()):
                     LOG.warning("Skipping file_info entry with missing or invalid path")
                     continue
+
                 if path not in existing_paths:
                     dicom_file = DICOMFile(
                         file_path=path,
@@ -75,10 +91,13 @@ class DICOMAlbumCreator:
                     db.session.add(dicom_file)
                     existing_paths.add(path)
                     count += 1
+
                     if count % 500 == 0:
                         db.session.commit()
+
             db.session.commit()
             return True
+
         except Exception:
             db.session.rollback()
             LOG.exception("Error indexing files")

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -12,9 +12,9 @@ class DICOMAlbumCreator:
         
     def scan_directory(self, path: str) -> List[Dict]:
         """Scan a directory for DICOM files and return metadata"""
-        root = Path(path)
+        root = self.storage_path / path
         if not root.exists() or not root.is_dir():
-            LOG.warning("Scan path does not exist or is not a directory: %s", path)
+            LOG.warning("Scan path does not exist or is not a directory: %s", root)
             return []
         dicom_files = []
         for dcm_path in root.rglob('*'):

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -22,7 +22,7 @@ class DICOMAlbumCreator:
             if not root.is_dir():
                 raise ValueError
 
-        except (ValueError, RuntimeError):
+        except (ValueError, RuntimeError, OSError, TypeError):
             LOG.warning(
                 "Scan path is invalid, unauthorized, or not a directory: %s",
                 path,

--- a/Diomedex/albums/core.py
+++ b/Diomedex/albums/core.py
@@ -42,7 +42,7 @@ class DICOMAlbumCreator:
                     continue
 
                 dicom_files.append({
-                    'path': str(dcm_path),
+                    'path': str(dcm_path.relative_to(base)),
                     'patient_id': ds.get('PatientID', ''),
                     'study_uid': ds.get('StudyInstanceUID', ''),
                     'modality': ds.get('Modality', ''),


### PR DESCRIPTION
## Summary
Improve robustness of DICOM directory scanning by validating input paths and handling file parsing failures gracefully.

## Changes
- Added early validation for scan directory path (existence and directory check)
- Reused resolved root path instead of recreating Path objects
- Wrapped DICOM parsing in try/except to prevent a single bad file from breaking the scan
- Added logging for invalid paths and parsing failures

## Motivation
Previously, invalid or non-directory paths could lead to unclear behavior or silent failures during traversal. Additionally, parsing errors in individual DICOM files could interrupt the entire scan process.

## Behavior
- Invalid scan paths now return an empty list with a warning log
- Corrupt or unreadable DICOM files are skipped with error logging
- Valid files continue to be processed normally

## Risk
Low behavior remains consistent for valid inputs, with improved handling of edge cases and failures