### PR TITLE
fix: atomic destination selection and queue reservation

### DIFF
--- a/Diomedex/routing/destinations.py
+++ b/Diomedex/routing/destinations.py
@@ -86,6 +86,17 @@ class DestinationManager:
                 return None
             
             return max(available, key=lambda d: d.calculate_score())
+        
+    def select_and_reserve(self):
+        with self._lock:
+            available = [d for d in self.destinations.values() if d.is_available]
+            if not available:
+                return None
+
+            best = max(available, key=lambda d: d.calculate_score())
+            best.current_queue += 1
+            best.sent_count += 1
+            return best
     
     def update_status(self, name, status, queue=None, response_time=None):
         with self._lock:

--- a/Diomedex/routing/router.py
+++ b/Diomedex/routing/router.py
@@ -31,14 +31,13 @@ class DICOMRouter:
         """Route DICOM dataset to best available destination"""
         self.total_received += 1
         
-        destination = self.destination_manager.select_best()
+        destination = self.destination_manager.select_and_reserve()
         if not destination:
             self.total_failed += 1
             return False
         
         try:
-            # Optimistically record the send attempt. This increments the queue and sent_count.
-            self.destination_manager.record_send(destination.name)
+            # Queue slot and sent_count are already updated by select_and_reserve()
             
             # TODO: actual DICOM C-STORE with pynetdicom  
             # For now just track the routing decision


### PR DESCRIPTION
fixes #154 

to address the issue, i have introduced an atomic selection method `select_and_reserve()` in `DestinationManager` which performs both selection and queue reservation under the same lock
```python
def select_and_reserve(self):
    with self._lock:
        available = [d for d in self.destinations.values() if d.is_available]
        if not available:
            return None

        best = max(available, key=lambda d: d.calculate_score())
        best.current_queue += 1
        best.sent_count += 1
        return best
```
and also updated the routing logic in `router.py` to use this method directly
```python
destination = self.destination_manager.select_and_reserve()
```
i  have also removed the redundant `record_send()` call since queue increment and `sent_count` are now handled within the atomic method itself due to which there is no double counting now, also ensured that the router consistently uses `self.destination_manager` instead of any global instance

wanted to clarify it can be further extended to deprecate `select_best()` where appropriate or add safeguards around queue limits as a follow-up (and have kept this pr scope oriented)