### PR TITLE
Add type validation for src and dest in anonymization endpoint

### DIFF
--- a/Diomedex/anonymization/routes.py
+++ b/Diomedex/anonymization/routes.py
@@ -56,6 +56,9 @@ def anonymize_directory():
     if "src" not in data or "dest" not in data:
         return jsonify({"error": "'src' and 'dest' parameters are required"}), 400
 
+    if not isinstance(data.get("src"), str) or not isinstance(data.get("dest"), str):
+        return jsonify({"error": "'src' and 'dest' must be strings"}), 400
+
     try:
         src_dir = _validate_path(data["src"])
         # src is intentionally not restricted to STORAGE_PATH. It is treated as


### PR DESCRIPTION
## Summary
Adds input type validation for `src` and `dest` parameters in the anonymization endpoint to prevent invalid payloads from causing runtime errors.

## Changes
- Added explicit checks to ensure `src` and `dest` are strings
- Returns a 400 Bad Request when invalid types are provided

## Motivation
Previously, non-string values (e.g., null, numbers, lists) could reach the path validation logic and cause unexpected exceptions when passed to `Path()`, resulting in 500 responses. This change ensures invalid input is handled gracefully and consistently.

## Behavior
- Valid requests remain unchanged
- Invalid types now return a clear 400 error instead of triggering internal server errors

## Risk
Low  change is limited to input validation and does not affect existing valid workflows